### PR TITLE
Review for DM-3483: don't throw when transforming negative fluxes

### DIFF
--- a/include/lsst/meas/base/FluxUtilities.h
+++ b/include/lsst/meas/base/FluxUtilities.h
@@ -209,6 +209,21 @@ private:
     MagResultKey _magKey;
 };
 
+/**
+ *  Temporarily replace negative fluxes with NaNs
+ *
+ *  Instantiating a NoThrowOnNegativeFluxContext object will cause afw::image::Calib
+ *  objects to return NaN, rather than throwing, when asked to convert a negative flux to
+ *  a magnitude for the lifetime of the NoThrowOnNegativeFluxContext.
+ */
+class NoThrowOnNegativeFluxContext {
+public:
+    NoThrowOnNegativeFluxContext();
+    ~NoThrowOnNegativeFluxContext();
+private:
+    bool _throwOnNegative;
+};
+
 }}} // lsst::meas::base
 
 #endif // !LSST_MEAS_BASE_FluxUtilities_h_INCLUDED

--- a/src/ApertureFlux.cc
+++ b/src/ApertureFlux.cc
@@ -354,10 +354,15 @@ void ApertureFluxTransform::operator()(
     }
     afw::table::SourceCatalog::const_iterator inSrc = inputCatalog.begin();
     afw::table::BaseCatalog::iterator outSrc = outputCatalog.begin();
-    for (; inSrc < inputCatalog.end() && outSrc < outputCatalog.end(); ++inSrc, ++outSrc) {
-        for (std::size_t i = 0; i < _ctrl.radii.size(); ++i) {
-            FluxResult fluxResult = fluxKeys[i].get(*inSrc);
-            _magKeys[i].set(*outSrc, calib.getMagnitude(fluxResult.flux, fluxResult.fluxSigma));
+    {
+        // While noThrow is in scope, converting a negative flux to a magnitude
+        // returns NaN rather than throwing.
+        NoThrowOnNegativeFluxContext noThrow;
+        for (; inSrc < inputCatalog.end() && outSrc < outputCatalog.end(); ++inSrc, ++outSrc) {
+            for (std::size_t i = 0; i < _ctrl.radii.size(); ++i) {
+                FluxResult fluxResult = fluxKeys[i].get(*inSrc);
+                _magKeys[i].set(*outSrc, calib.getMagnitude(fluxResult.flux, fluxResult.fluxSigma));
+            }
         }
     }
 }

--- a/src/ApertureFlux.cc
+++ b/src/ApertureFlux.cc
@@ -358,7 +358,7 @@ void ApertureFluxTransform::operator()(
         // While noThrow is in scope, converting a negative flux to a magnitude
         // returns NaN rather than throwing.
         NoThrowOnNegativeFluxContext noThrow;
-        for (; inSrc < inputCatalog.end() && outSrc < outputCatalog.end(); ++inSrc, ++outSrc) {
+        for (; inSrc != inputCatalog.end() && outSrc != outputCatalog.end(); ++inSrc, ++outSrc) {
             for (std::size_t i = 0; i < _ctrl.radii.size(); ++i) {
                 FluxResult fluxResult = fluxKeys[i].get(*inSrc);
                 _magKeys[i].set(*outSrc, calib.getMagnitude(fluxResult.flux, fluxResult.fluxSigma));

--- a/src/CentroidUtilities.cc
+++ b/src/CentroidUtilities.cc
@@ -170,7 +170,7 @@ void CentroidTransform::operator()(
     afw::table::SourceCatalog::const_iterator inSrc = inputCatalog.begin();
     afw::table::BaseCatalog::iterator outSrc = outputCatalog.begin();
 
-    for (; inSrc < inputCatalog.end() && outSrc < outputCatalog.end(); ++inSrc, ++outSrc) {
+    for (; inSrc != inputCatalog.end() && outSrc != outputCatalog.end(); ++inSrc, ++outSrc) {
         CentroidResult centroidResult = centroidResultKey.get(*inSrc);
 
         _coordKey.set(*outSrc, *wcs.pixelToSky(centroidResult.getCentroid()));

--- a/src/FluxUtilities.cc
+++ b/src/FluxUtilities.cc
@@ -108,7 +108,7 @@ void FluxTransform::operator()(
         // While noThrow is in scope, converting a negative flux to a magnitude
         // returns NaN rather than throwing.
         NoThrowOnNegativeFluxContext noThrow;
-        for (; inSrc < inputCatalog.end() && outSrc < outputCatalog.end(); ++inSrc, ++outSrc) {
+        for (; inSrc != inputCatalog.end() && outSrc != outputCatalog.end(); ++inSrc, ++outSrc) {
             FluxResult fluxResult = fluxKey.get(*inSrc);
             _magKey.set(*outSrc, calib.getMagnitude(fluxResult.flux, fluxResult.fluxSigma));
         }

--- a/src/SdssShape.cc
+++ b/src/SdssShape.cc
@@ -935,7 +935,7 @@ void SdssShapeTransform::operator()(
 
     afw::table::SourceCatalog::const_iterator inSrc = inputCatalog.begin();
     afw::table::BaseCatalog::iterator outSrc = outputCatalog.begin();
-    for (; inSrc < inputCatalog.end(); ++inSrc, ++outSrc) {
+    for (; inSrc != inputCatalog.end(); ++inSrc, ++outSrc) {
         ShapeResult inShape = inShapeKey.get(*inSrc);
         ShapeResult outShape;
 

--- a/tests/testSdssShape.py
+++ b/tests/testSdssShape.py
@@ -91,11 +91,12 @@ class SdssShapeTransformTestCase(FluxTransformTestCase, CentroidTransformTestCas
     singleFramePlugins = ('base_SdssShape',)
     forcedPlugins = ('base_SdssShape',)
 
-    def _setFieldsInRecord(self, record, name):
-        FluxTransformTestCase._setFieldsInRecord(self, record, name)
-        CentroidTransformTestCase._setFieldsInRecord(self, record, name)
-        for field in ('xx', 'yy', 'xy', 'xxSigma', 'yySigma', 'xySigma'):
-            record[record.schema.join(name, field)] = numpy.random.random()
+    def _setFieldsInRecords(self, records, name):
+        FluxTransformTestCase._setFieldsInRecords(self, records, name)
+        CentroidTransformTestCase._setFieldsInRecords(self, records, name)
+        for record in records:
+            for field in ('xx', 'yy', 'xy', 'xxSigma', 'yySigma', 'xySigma'):
+                record[record.schema.join(name, field)] = numpy.random.random()
 
     def _compareFieldsInRecords(self, inSrc, outSrc, name):
         FluxTransformTestCase._compareFieldsInRecords(self, inSrc, outSrc, name)


### PR DESCRIPTION
When transforming data to calibrated form for database ingest we should not
allow the process to be derailed by a negative flux measurement.