### PR TITLE
ApplyApCorrTask.run: fix test for models in apCorrMap DM-3460

### DIFF
--- a/python/lsst/meas/base/applyApCorr.py
+++ b/python/lsst/meas/base/applyApCorr.py
@@ -144,11 +144,12 @@ class ApplyApCorrTask(lsst.pipe.base.Task):
             self.log.info("Use complex flux sigma computation that double-counts photon noise "
                 " and thus over-estimates flux uncertainty")
         for apCorrInfo in self.apCorrInfoDict.itervalues():
-            try:
-                apCorrModel = apCorrMap.get(apCorrInfo.fluxName)
-                apCorrSigmaModel = apCorrMap.get(apCorrInfo.fluxSigmaName)
-            except Exception:
-                self.log.warn("Could not find %s in apCorrMap" % (apCorrInfo.name,))
+            apCorrModel = apCorrMap.get(apCorrInfo.fluxName)
+            apCorrSigmaModel = apCorrMap.get(apCorrInfo.fluxSigmaName)
+            if None in (apCorrModel, apCorrSigmaModel):
+                missingNames = [(apCorrInfo.fluxName, apCorrInfo.fluxSigmaName)[i]
+                    for i, model in enumerate((apCorrModel, apCorrSigmaModel)) if model is None]
+                self.log.warn("Could not find %s in apCorrMap" % (" or ".join(missingNames),))
                 for source in catalog:
                     source.set(apCorrInfo.apCorrFlagKey, True)
                 continue


### PR DESCRIPTION
Fixed the test that determined if the required models for flux
and fluxSigma were present in the aperture correction map.
The test incorrectly assumed that ApCorrMap.get raised an
exception if a field was missing; in fact it returns None.
Tested using a slightly hacked version of
meas_extensions_photometryKron tests/Kron.py
since we don't yet have a unit test for appling ap. corr.