### PR TITLE
DM-5879 Remove use of Boost smart pointers throughout the Science Pipelines

### DIFF
--- a/src/ApertureFlux.cc
+++ b/src/ApertureFlux.cc
@@ -146,7 +146,7 @@ CONST_PTR(afw::image::Image<T>) getSincCoeffs(
             result.setFlag(ApertureFluxAlgorithm::APERTURE_TRUNCATED);
             result.setFlag(ApertureFluxAlgorithm::FAILURE);
         }
-        cImage = boost::make_shared< afw::image::Image<T> >(*cImage, overlap);
+        cImage = std::make_shared< afw::image::Image<T> >(*cImage, overlap);
     }
     return cImage;
 }

--- a/src/Blendedness.cc
+++ b/src/Blendedness.cc
@@ -49,7 +49,7 @@ double computeOldBlendedness(
     }
 
     PTR(afw::detection::HeavyFootprint<float> const) childHeavy =
-        boost::dynamic_pointer_cast<afw::detection::HeavyFootprint<float> const>(childFootprint);
+        std::dynamic_pointer_cast<afw::detection::HeavyFootprint<float> const>(childFootprint);
 
     if (!childHeavy) {
         return 0.0;  // if it's not a HeavyFootprint, it's not blended.

--- a/src/CircularApertureFlux.cc
+++ b/src/CircularApertureFlux.cc
@@ -47,7 +47,7 @@ void CircularApertureFluxAlgorithm::measure(
 ) const {
     afw::geom::ellipses::Ellipse ellipse(afw::geom::ellipses::Axes(1.0, 1.0, 0.0));
     PTR(afw::geom::ellipses::Axes) axes
-        = boost::static_pointer_cast<afw::geom::ellipses::Axes>(ellipse.getCorePtr());
+        = std::static_pointer_cast<afw::geom::ellipses::Axes>(ellipse.getCorePtr());
     for (std::size_t i = 0; i < _ctrl.radii.size(); ++i) {
         // Each call to _centroidExtractor within this loop goes through exactly the same error-checking
         // logic and returns the same result, but it's not expensive logic, so we just call it repeatedly

--- a/src/SincCoeffs.cc
+++ b/src/SincCoeffs.cc
@@ -237,7 +237,7 @@ calcImageRealSpace(double const rad1, double const rad2, double const taperwidth
 
     // create an image to hold the coefficient image
     typename afw::image::Image<PixelT>::Ptr coeffImage =
-        boost::make_shared<afw::image::Image<PixelT> >(afw::geom::ExtentI(xwidth, ywidth), initweight);
+        std::make_shared<afw::image::Image<PixelT> >(afw::geom::ExtentI(xwidth, ywidth), initweight);
     coeffImage->setXY0(x0, y0);
 
     // create the aperture function object
@@ -400,7 +400,7 @@ typename afw::image::Image<PixelT>::Ptr calcImageKSpaceCplx(double const rad1, d
 
     // put the coefficients into an image
     typename afw::image::Image<PixelT>::Ptr coeffImage =
-        boost::make_shared<afw::image::Image<PixelT> >(afw::geom::ExtentI(wid, wid), 0.0);
+        std::make_shared<afw::image::Image<PixelT> >(afw::geom::ExtentI(wid, wid), 0.0);
 
     for (int iY = 0; iY != coeffImage->getHeight(); ++iY) {
         int iX = 0;
@@ -478,7 +478,7 @@ typename afw::image::Image<PixelT>::Ptr calcImageKSpaceReal(double const rad1, d
 
     // put the coefficients into an image
     typename afw::image::Image<PixelT>::Ptr coeffImage =
-        boost::make_shared<afw::image::Image<PixelT> >(afw::geom::ExtentI(wid, wid), 0.0);
+        std::make_shared<afw::image::Image<PixelT> >(afw::geom::ExtentI(wid, wid), 0.0);
 
     for (int iY = 0; iY != coeffImage->getHeight(); ++iY) {
         int iX = 0;


### PR DESCRIPTION
Makes the following replacements:

- boost::scoped_ptr -> std::unique_ptr
- boost::shared_ptr -> std::shared_ptr
- boost::weak_ptr -> std::weak_ptr
- boost::static_pointer_cast -> std::static_pointer_cast
- boost::dynamic_pointer_cast -> std::dynamic_pointer_cast
- boost::const_pointer_cast -> std::const_pointer_cast
- boost::reinterpret_pointer_cast -> std::reinterpret_pointer_cast
- boost::enamble_shared_from_this -> std::enable_shared_from_this
- boost pointer related includes -> standard library memory
