### PR TITLE
Rename afterburner to catalogCalculation

### DIFF
--- a/python/lsst/meas/base/__init__.py
+++ b/python/lsst/meas/base/__init__.py
@@ -15,4 +15,4 @@ from .forcedPhotCoadd import *
 from .transforms import *
 from .applyApCorr import *
 from .wrappers import *
-from .afterburner import *
+from .catalogCalculation import *

--- a/python/lsst/meas/base/catalogCalculation.py
+++ b/python/lsst/meas/base/catalogCalculation.py
@@ -163,11 +163,10 @@ class CatalogCalculationTask(lsst.pipe.base.Task):
                 elif plug.plugType == 'multi':
                     self.executionDict[executionOrder].multi.append(plug)
             else:
+                errorTuple = (PluginClass, PluginClass.getExecutionOrder(),
+                              BasePlugin.DEFAULT_CATALOGCALCULATION)
                 raise ValueError("{} has an execution order less than the minimum for an catalogCalculation "
-                                 "plugin. Value {} : Minimum {}".format(PluginClass,
-                                                                        PluginClass.getExecutionOrder(),
-                                                                        BasePlugin.DEFAULT_CATALOGCALCULATION)
-                                )
+                                 "plugin. Value {} : Minimum {}".format(*errorTuple))
 
     def run(self, measCat):
         '''

--- a/python/lsst/meas/base/classification.py
+++ b/python/lsst/meas/base/classification.py
@@ -27,15 +27,15 @@ Definition and registration of classification plugins
 import numpy
 
 import lsst.pex.config
-from .afterburner import AfterburnerPluginConfig, AfterburnerPlugin
+from .catalogCalculation import CatalogCalculationPluginConfig, CatalogCalculationPlugin
 from .pluginRegistry import register
 
 __all__ = (
-    "AfterburnerClassificationConfig", "AfterburnerClassificationPlugin",
+    "CatalogCalculationClassificationConfig", "CatalogCalculationClassificationPlugin",
 )
 
 
-class AfterburnerClassificationConfig(AfterburnerPluginConfig):
+class CatalogCalculationClassificationConfig(CatalogCalculationPluginConfig):
     fluxRatio = lsst.pex.config.Field(dtype=float, default=.925, optional=True,
                                       doc="critical ratio of model to psf flux")
     modelErrFactor = lsst.pex.config.Field(dtype=float, default=0.0, optional=True,
@@ -45,7 +45,7 @@ class AfterburnerClassificationConfig(AfterburnerPluginConfig):
 
 
 @register("base_ClassificationExtendedness")
-class AfterburnerClassificationPlugin(AfterburnerPlugin):
+class CatalogCalculationClassificationPlugin(CatalogCalculationPlugin):
     """
     A binary measure of the extendedness of a source, based a simple cut on the ratio of the
     PSF flux to the model flux.
@@ -57,19 +57,19 @@ class AfterburnerClassificationPlugin(AfterburnerPlugin):
     begins.
     """
 
-    ConfigClass = AfterburnerClassificationConfig
+    ConfigClass = CatalogCalculationClassificationConfig
 
     @classmethod
     def getExecutionOrder(cls):
-        return cls.DEFAULT_AFTERBURNER
+        return cls.DEFAULT_CATALOGCALCULATION
 
     def __init__(self, config, name, schema, metadata):
-        AfterburnerPlugin.__init__(self, config, name, schema, metadata)
+        CatalogCalculationPlugin.__init__(self, config, name, schema, metadata)
         self.keyProbability = schema.addField(name + "_value", type="D",
                                               doc="Set to 1 for extended sources, 0 for point sources.")
         self.keyFlag = schema.addField(name + "_flag", type="Flag", doc="Set to 1 for any fatal failure.")
 
-    def burn(self, measRecord):
+    def calculate(self, measRecord):
         modelFlux = measRecord.getModelFlux()
         psfFlux = measRecord.getPsfFlux()
         modelFluxFlag = (measRecord.getModelFluxFlag()

--- a/python/lsst/meas/base/pluginsBase.py
+++ b/python/lsst/meas/base/pluginsBase.py
@@ -51,7 +51,7 @@ class BasePlugin(object):
     SHAPE_ORDER = 1.0
     FLUX_ORDER = 2.0
     APCORR_ORDER = 3.0
-    DEFAULT_AFTERBURNER = 4.0
+    DEFAULT_CATALOGCALCULATION = 4.0
 
     @classmethod
     def getExecutionOrder(cls):
@@ -65,7 +65,7 @@ class BasePlugin(object):
                             a good centroid (in addition to a Footprint and its Peaks).
         FLUX_ORDER          flux algorithms that require both getShape() and getCentroid(),
                             in addition to a Footprint and its Peaks
-        DEFAULT_AFTERBURNER plugins that only operate on the catalog
+        DEFAULT_CATALOGCALCULATION plugins that only operate on the catalog
 
         Must be reimplemented as a class method by concrete derived classes.
 

--- a/tests/testCatalogCalculation.py
+++ b/tests/testCatalogCalculation.py
@@ -4,50 +4,49 @@ from builtins import range
 import unittest
 import lsst.utils.tests
 
-import lsst.meas.base.afterburner as afterBurner
+import lsst.meas.base.catalogCalculation as catCalc
 import lsst.afw.table as afwTable
 from lsst.meas.base.pluginRegistry import register
 from lsst.meas.base.baseLib import MeasurementError
 from lsst.meas.base import FlagHandler
 
 
-@register("afterburnerFail")
-class FailAb(afterBurner.AfterburnerPlugin):
-    """Afterburner plugin which is guaranteed to fail, testing the failure framework."""
-
+@register("FailcatalogCalculation")
+class FailCC(catCalc.CatalogCalculationPlugin):
+    '''
+    catalogCalculation plugin which is guaranteed to fail, testing the failure framework
+    '''
     @classmethod
     def getExecutionOrder(cls):
-        return cls.DEFAULT_AFTERBURNER
+        return cls.DEFAULT_CATALOGCALCULATION
 
     def __init__(self, config, name, schema, metadata):
-        afterBurner.AfterburnerPlugin.__init__(self, config, name, schema, metadata)
+        catCalc.CatalogCalculationPlugin.__init__(self, config, name, schema, metadata)
         self.failKey = schema.addField(name + "_fail", type="Flag", doc="Failure test")
 
-    def burn(self, measRecord):
+    def calculate(self, measRecord):
         raise MeasurementError("Supposed to fail", FlagHandler.FAILURE)
 
     def fail(self, measRecord, error=None):
         measRecord.set(self.failKey, True)
 
 
-@register("singleRecordAfterburner")
-class SingleRecordAb(afterBurner.AfterburnerPlugin):
-    """Afterburner plugin which works in single mode."""
-
-    """
-    It takes a single record, reads a value, squares it, and
-    writes out the results to the record
-    """
+@register("singleRecordCatalogCalculation")
+class SingleRecordCC(catCalc.CatalogCalculationPlugin):
+    '''
+    CatalogCalculation plugin which works in single mode. It takes a single record, reads a value, squares it,
+    and writes out the results to the record
+    '''
     @classmethod
     def getExecutionOrder(cls):
-        return cls.DEFAULT_AFTERBURNER
+        return cls.DEFAULT_CATALOGCALCULATION
 
     def __init__(self, config, name, schema, metadata):
-        afterBurner.AfterburnerPlugin.__init__(self, config, name, schema, metadata)
+        catCalc.CatalogCalculationPlugin.__init__(self, config, name, schema, metadata)
         self.failKey = schema.addField(name + "_fail", type="Flag", doc="Failure flag")
         self.squareKey = schema.addField(name + "_square", type="D", doc="Square of input catalog")
 
-    def burn(self, measRecord):
+    def calculate(self, measRecord):
         value = measRecord.get("start")
         measRecord.set(self.squareKey, value**2)
 
@@ -55,12 +54,10 @@ class SingleRecordAb(afterBurner.AfterburnerPlugin):
         measRecord.set(self.failKey, True)
 
 
-@register("multiRecordAfterburner")
-class MultiRecordAb(afterBurner.AfterburnerPlugin):
-    """Afterburner plugin to test the framework in multimode."""
-
+@register("multiRecordCatalogCalculation")
+class MultiRecordAb(catCalc.CatalogCalculationPlugin):
     """
-    This plugin takes the whole source catalog at
+    CatalogCalcuation plugin to test the framework in multimode. This plugin takes the whole source catalog at
     once, and loops over the catalog internally. The algorithm simply reads a value, cubes it, and writes the
     results out to the table
     """
@@ -68,14 +65,14 @@ class MultiRecordAb(afterBurner.AfterburnerPlugin):
 
     @classmethod
     def getExecutionOrder(cls):
-        return cls.DEFAULT_AFTERBURNER
+        return cls.DEFAULT_CATALOGCALCULATION
 
     def __init__(self, config, name, schema, metadata):
-        afterBurner.AfterburnerPlugin.__init__(self, config, name, schema, metadata)
+        catCalc.CatalogCalculationPlugin.__init__(self, config, name, schema, metadata)
         self.failKey = schema.addField(name + "_fail", type="Flag", doc="Failure flag")
         self.cubeKey = schema.addField(name + "_cube", type="D", doc="Cube of input catalog")
 
-    def burn(self, catalog):
+    def calculate(self, catalog):
         for rec in catalog:
             value = rec.get("start")
             rec.set(self.cubeKey, value**3)
@@ -85,71 +82,70 @@ class MultiRecordAb(afterBurner.AfterburnerPlugin):
             value = rec.set(self.failKey, True)
 
 
-@register("dependentAfterburner")
-class DependentAb(afterBurner.AfterburnerPlugin):
-    """Afterburner plugin to test the runlevel resolution."""
-
-    """
-    This plugin takes in single records, reads a value
-    from a previous plugin computes a square root, and writes the results to the table.
-    """
+@register("dependentCatalogCalulation")
+class DependentAb(catCalc.CatalogCalculationPlugin):
+    '''
+    CatalogCalculation plugin to test the runlevel resolution. This plugin takes in single records, reads a
+    value from a previous plugin computes a square root, and writes the results to the table.
+    '''
     @classmethod
     def getExecutionOrder(cls):
-        return cls.DEFAULT_AFTERBURNER + 1
+        return cls.DEFAULT_CATALOGCALCULATION + 1
 
     def __init__(self, config, name, schema, metadata):
-        afterBurner.AfterburnerPlugin.__init__(self, config, name, schema, metadata)
+        catCalc.CatalogCalculationPlugin.__init__(self, config, name, schema, metadata)
         self.failKey = schema.addField(name + "_fail", type="Flag", doc="Failure flag")
         self.sqrtKey = schema.addField(name + "_sqrt", type="D",
-                                       doc="Square root of singleRecord afterburner")
+                                       doc="Square root of singleRecord catalogCalculation")
 
-    def burn(self, measRecord):
-        value = measRecord.get("singleRecordAfterburner_square")
+    def calculate(self, measRecord):
+        value = measRecord.get("singleRecordCatalogCalculation_square")
         measRecord.set(self.sqrtKey, value**0.5)
 
     def fail(self, measRecord, error=None):
         measRecord.set(self.failKey, True)
 
 
-class AfterburnerTest(lsst.utils.tests.TestCase):
-    """Test the after burner framework, running only the plugins defined above."""
-
+class CatalogCalculationTest(unittest.TestCase):
+    '''
+    Test the catalogCalculation framework, running only the plugins defined above
+    '''
     def setUp(self):
         # Create a schema object, and populate it with a field to simulate results from measurements on an
         # image
         schema = afwTable.SourceTable.makeMinimalSchema()
         startKey = schema.addField("start", type="D")
         # Instantiate a config object adding each of the above plugins, and use it to create a task
-        abConfig = afterBurner.AfterburnerConfig()
-        abConfig.plugins.names = ["afterburnerFail", "singleRecordAfterburner",
-                                  "multiRecordAfterburner", "dependentAfterburner"]
-        abTask = afterBurner.AfterburnerTask(schema=schema, config=abConfig)
+        catCalcConfig = catCalc.CatalogCalculationConfig()
+        catCalcConfig.plugins.names = ["FailcatalogCalculation", "singleRecordCatalogCalculation",
+                                       "multiRecordCatalogCalculation", "dependentCatalogCalulation"]
+        catCalcTask = catCalc.CatalogCalculationTask(schema=schema, config=catCalcConfig)
         # Create a catalog with five sources as input to the task
         self.catalog = afwTable.SourceCatalog(schema)
         self.numObjects = 5
         for i in range(self.numObjects):
             rec = self.catalog.addNew()
             rec.set("start", float(i + 1))
-        # Run the afterburner task, outputs will be checked in test methods
-        abTask.run(self.catalog)
+        # Run the catalogCalculation task, outputs will be checked in test methods
+        catCalcTask.run(self.catalog)
 
-    def testAfterburners(self):
+    def testCatalogCalculation(self):
         # Verify the failure flag got set for the plugin expected to fail
         self.assertEqual(len(self.catalog), self.numObjects)
         for src in self.catalog:
-            self.assertTrue(src.get("afterburnerFail_fail"))
+            self.assertTrue(src.get("FailcatalogCalculation_fail"))
 
         # Verify the single record plugin ran successfully
         for rec in self.catalog:
-            self.assertAlmostEqual(rec.get("start")**2, rec.get("singleRecordAfterburner_square"), 4)
+            self.assertAlmostEqual(rec.get("start")**2, rec.get("singleRecordCatalogCalculation_square"), 4)
 
         # Verify that the system correctly handled a plugin which expects a full catalog to be passed
         for rec in self.catalog:
-            self.assertAlmostEqual(rec.get("start")**3, rec.get("multiRecordAfterburner_cube"), 4)
+            self.assertAlmostEqual(rec.get("start")**3, rec.get("multiRecordCatalogCalculation_cube"), 4)
 
         # Verify that the system runs plugins in the correct run order
         for rec in self.catalog:
-            self.assertAlmostEqual(rec.get("start"), rec.get("dependentAfterburner_sqrt"), 4)
+            self.assertAlmostEqual(rec.get("start"), rec.get("dependentCatalogCalulation_sqrt"), 4)
 
     def tearDown(self):
         del self.catalog, self.numObjects,

--- a/tests/testCatalogCalculation.py
+++ b/tests/testCatalogCalculation.py
@@ -79,7 +79,7 @@ class MultiRecordAb(catCalc.CatalogCalculationPlugin):
 
     def fail(self, catalog, error=None):
         for rec in catalog:
-            value = rec.set(self.failKey, True)
+            rec.set(self.failKey, True)
 
 
 @register("dependentCatalogCalulation")
@@ -114,7 +114,7 @@ class CatalogCalculationTest(unittest.TestCase):
         # Create a schema object, and populate it with a field to simulate results from measurements on an
         # image
         schema = afwTable.SourceTable.makeMinimalSchema()
-        startKey = schema.addField("start", type="D")
+        schema.addField("start", type="D")
         # Instantiate a config object adding each of the above plugins, and use it to create a task
         catCalcConfig = catCalc.CatalogCalculationConfig()
         catCalcConfig.plugins.names = ["FailcatalogCalculation", "singleRecordCatalogCalculation",

--- a/tests/testClassification.py
+++ b/tests/testClassification.py
@@ -27,8 +27,7 @@ import unittest
 import lsst.utils.tests
 import lsst.meas.base.tests
 import lsst.meas.base as measBase
-import lsst.meas.base.afterburner as afterburners
-
+import lsst.meas.base.catalogCalculation as catCalc
 
 class ClassificationTestCase(lsst.meas.base.tests.AlgorithmTestCase, lsst.utils.tests.TestCase):
 
@@ -52,7 +51,7 @@ class ClassificationTestCase(lsst.meas.base.tests.AlgorithmTestCase, lsst.utils.
         config.slots.psfFlux = "base_PsfFlux"
         config.slots.modelFlux = "truth"
         task = self.makeSingleFrameMeasurementTask(config=config)
-        abTask = afterburners.AfterburnerTask(schema=task.schema)
+        abTask = catCalc.CatalogCalculationTask(schema=task.schema)
         exposure, catalog = self.dataset.realize(10.0, task.schema)
         task.run(exposure, catalog)
         abTask.run(catalog)
@@ -73,13 +72,13 @@ class ClassificationTestCase(lsst.meas.base.tests.AlgorithmTestCase, lsst.utils.
         config.slots.psfFlux = "base_PsfFlux"
         config.slots.modelFlux = "base_GaussianFlux"
 
-        abConfig = afterburners.AfterburnerConfig()
+        abConfig = catCalc.CatalogCalculationConfig()
 
         def runFlagTest(psfFlux=100.0, modelFlux=200.0,
                         psfFluxSigma=1.0, modelFluxSigma=2.0,
                         psfFluxFlag=False, modelFluxFlag=False):
             task = self.makeSingleFrameMeasurementTask(config=config)
-            abTask = afterburners.AfterburnerTask(schema=task.schema, config=abConfig)
+            abTask = catCalc.CatalogCalculationTask(schema=task.schema, config=abConfig)
             exposure, catalog = self.dataset.realize(10.0, task.schema)
             source = catalog[0]
             source.set("base_PsfFlux_flux", psfFlux)
@@ -88,7 +87,7 @@ class ClassificationTestCase(lsst.meas.base.tests.AlgorithmTestCase, lsst.utils.
             source.set("base_GaussianFlux_flux", modelFlux)
             source.set("base_GaussianFlux_fluxSigma", modelFluxSigma)
             source.set("base_GaussianFlux_flag", modelFluxFlag)
-            abTask.plugins["base_ClassificationExtendedness"].burn(source)
+            abTask.plugins["base_ClassificationExtendedness"].calculate(source)
             return source.get("base_ClassificationExtendedness_flag")
 
         #  Test no error case - all necessary values are set


### PR DESCRIPTION
To improve readability and limit ambiguity in function, afterburners
is renamed to catalogCalculation