### PR TITLE
DM-7753: Fail gracefully when CentroidChecker can't get a Peak.

### DIFF
--- a/src/CentroidUtilities.cc
+++ b/src/CentroidUtilities.cc
@@ -215,13 +215,18 @@ bool CentroidChecker::operator()(
     if (!_doFootprintCheck && _maxDistFromPeak < 0.0) {
         return false;
     }
-
-    if (!record.getFootprint()) {
+    PTR(afw::detection::Footprint) footprint = record.getFootprint();
+    if (!footprint) {
         throw LSST_EXCEPT(
             pex::exceptions::RuntimeError,
             "No Footprint attached to record");
     }
-    PTR(afw::detection::Footprint) footprint = record.getFootprint();
+    if (footprint->getPeaks().empty()) {
+        throw LSST_EXCEPT(
+            pex::exceptions::RuntimeError,
+            "Footprint has no peaks; cannot verify centroid."
+        );
+    }
     CentroidElement footX = footprint->getPeaks().front().getFx();
     CentroidElement footY = footprint->getPeaks().front().getFy();
     double distsq = (x - footX) * (x - footX) + (y - footY) * (y - footY);

--- a/src/GaussianCentroid.cc
+++ b/src/GaussianCentroid.cc
@@ -45,7 +45,7 @@ struct Fit2d {
     typedef Eigen::Matrix<double, FittedModel::NPARAM, 1> Vector;
 
     template<typename PixelT>
-    explicit Fit2d(afw::image::Image<PixelT> const& im) : wide(32), rast(*new std::vector<Raster>(wide*wide)) {
+    explicit Fit2d(afw::image::Image<PixelT> const& im) : wide(32), rast(wide*wide) {
         ncols = im.getWidth();
         nrows = im.getHeight();
 
@@ -62,12 +62,9 @@ struct Fit2d {
         iter = 0;
         flamd = 1.0;
     }
-    ~Fit2d() {
-        delete &rast;
-    }
 
     int wide;                           // patch of image being fitted is wide*wide
-    std::vector<Raster> &rast;          // The pixels being fitted, thought of as a raster scan
+    std::vector<Raster> rast;          // The pixels being fitted, thought of as a raster scan
     int nin;
     int nref;
     int iter;


### PR DESCRIPTION
Also cleans up some unusual code in `GaussianCentroid` that turned out not to be the problem.