### PR TITLE
meas_base/DM-8221: Save the correct schema in forced photometry

### DIFF
--- a/python/lsst/meas/base/forcedPhotImage.py
+++ b/python/lsst/meas/base/forcedPhotImage.py
@@ -213,7 +213,7 @@ class ForcedPhotImageTask(lsst.pipe.base.CmdLineTask):
         In the case of forced taks, there is only one schema for each type of forced measurement.
         The dataset type for this measurement is defined in the mapper.
         """
-        catalog = lsst.afw.table.SourceCatalog(self.measurement.mapper.getOutputSchema())
+        catalog = lsst.afw.table.SourceCatalog(self.measurement.schema)
         catalog.getTable().setMetadata(self.measurement.algMetadata)
         datasetType = self.dataPrefix + "forced_src"
         return {datasetType: catalog}


### PR DESCRIPTION
Trivial change; note that diff is relative to DM-8210, which was necessary to get the test code (in pipe_tasks) working.  I will rebase after DM-8210 is merged.