### PR TITLE
meas_base/DM-8230: updates to forced photometry

### DIFF
--- a/python/lsst/meas/base/references.py
+++ b/python/lsst/meas/base/references.py
@@ -161,6 +161,11 @@ class CoaddSrcReferencesConfig(BaseReferencesTask.ConfigClass):
         dtype=str,
         default="deep",
     )
+    skipMissing = lsst.pex.config.Field(
+        doc="Silently skip patches where the reference catalog does not exist.",
+        dtype=bool,
+        default=False
+    )
 
     def validate(self):
         if (self.coaddName == "chiSquared") != (self.filter is None):
@@ -216,6 +221,8 @@ class CoaddSrcReferencesTask(BaseReferencesTask):
                 dataId['filter'] = self.config.filter
 
             if not butler.datasetExists(dataset, dataId):
+                if self.config.skipMissing:
+                    continue
                 raise lsst.pipe.base.TaskError("Reference %s doesn't exist" % (dataId,))
             self.log.info("Getting references in %s" % (dataId,))
             catalog = butler.get(dataset, dataId, immediate=True)


### PR DESCRIPTION
Two not-obviously-related changes here (on separate commits):
 - We remove a workaround in forced photometry data ID mangling that is now fixed in obs_base
 - We add a config option to support skipping missing patches in forced photometry, which we'll use to enable CCD forced photometry in `ci_hsc` without processing more coadd patches there.