### PR TITLE
DM-8461: Wrap pipe_tasks with pybind11

### DIFF
--- a/python/lsst/meas/base/baseLib.py
+++ b/python/lsst/meas/base/baseLib.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
 
+# Needed for pybind11-generated docstrings
+from lsst.afw.image import Calib, Wcs
+
 from ._centroidUtilities import *
 from ._fluxUtilities import *
 from ._inputUtilities import *

--- a/python/lsst/meas/base/forcedPhotImage.py
+++ b/python/lsst/meas/base/forcedPhotImage.py
@@ -205,7 +205,7 @@ class ForcedPhotImageTask(lsst.pipe.base.CmdLineTask):
                         is all that will be modified.
         @param sources  SourceCatalog to save
         """
-        dataRef.put(sources, self.dataPrefix + "forced_src", flags=lsst.afw.table.SOURCE_IO_NO_FOOTPRINTS)
+        dataRef.put(sources, self.dataPrefix + "forced_src", flags=int(lsst.afw.table.SOURCE_IO_NO_FOOTPRINTS))
 
     def getSchemaCatalogs(self):
         """!Get a dict of Schema catalogs that will be used by this Task.


### PR DESCRIPTION
Without this import, the docstring created for `SdssCentroidTransform` uses C++ names for the parameter types rather than python names.