### PR TITLE
DM-8454: Wrap meas_extensions_shapeHSM with pybind11

### DIFF
--- a/include/lsst/meas/base/pybind11.h
+++ b/include/lsst/meas/base/pybind11.h
@@ -72,6 +72,31 @@ typename std::enable_if<std::is_abstract<Algorithm>::value, void>::type declareA
 }
 
 /**
+ * Wrap the implicit API used by meas_base's algorithms.
+ *
+ * This function only initializes constructors, fields, and methods common to
+ * all Algorithms.
+ *
+ * @tparam Algorithm The algorithm class.
+ * @tparam PyAlg The `pybind11::class_` class corresponding to `Algorithm`.
+ *
+ * @param[in,out] clsAlgorithm The pybind11 wrapper for `Algorithm`.
+ */
+template <class Algorithm, class PyAlg>
+void declareAlgorithm(PyAlg & clsAlgorithm) {
+    /* Member types and enums */
+
+    /* Constructors */
+    declareAlgorithmConstructor<Algorithm>(clsAlgorithm);
+
+    /* Operators */
+
+    /* Members */
+    clsAlgorithm.def("fail", &Algorithm::fail, "measRecord"_a, "error"_a=NULL);
+    clsAlgorithm.def("measure", &Algorithm::measure, "record"_a, "exposure"_a);
+}
+
+/**
  * Wrap the implicit API used by meas_base's algorithm-control pairs (no transform).
  *
  * This function only initializes constructors, fields, and methods common to
@@ -88,18 +113,16 @@ typename std::enable_if<std::is_abstract<Algorithm>::value, void>::type declareA
  */
 template <class Algorithm, class Control, class PyAlg, class PyCtrl>
 void declareAlgorithm(PyAlg & clsAlgorithm, PyCtrl & clsControl) {
+    declareAlgorithm<Algorithm>(clsAlgorithm);
+
     /* Member types and enums */
 
     /* Constructors */
-    declareAlgorithmConstructor<Algorithm>(clsAlgorithm);
-
     clsControl.def(py::init<>());
 
     /* Operators */
 
     /* Members */
-    clsAlgorithm.def("fail", &Algorithm::fail, "measRecord"_a, "error"_a=NULL);
-    clsAlgorithm.def("measure", &Algorithm::measure, "record"_a, "exposure"_a);
 }
 
 /**

--- a/python/lsst/meas/base/algorithm.cc
+++ b/python/lsst/meas/base/algorithm.cc
@@ -25,6 +25,7 @@
 
 #include "lsst/afw/image/Wcs.h"
 #include "lsst/afw/table/Source.h"
+#include "lsst/meas/base/pybind11.h"
 #include "lsst/meas/base/Algorithm.h"
 
 namespace py = pybind11;
@@ -38,7 +39,8 @@ PYBIND11_PLUGIN(_algorithm) {
     py::module mod("_algorithm", "Python wrapper for afw _algorithm library");
 
     /* Module level */
-    py::class_<SimpleAlgorithm> clsSimpleAlgorithm(mod, "SimpleAlgorithm");
+    py::class_<SingleFrameAlgorithm> clsSingleFrameAlgorithm(mod, "SingleFrameAlgorithm");
+    py::class_<SimpleAlgorithm, SingleFrameAlgorithm> clsSimpleAlgorithm(mod, "SimpleAlgorithm");
 
     /* Member types and enums */
 
@@ -47,6 +49,8 @@ PYBIND11_PLUGIN(_algorithm) {
     /* Operators */
 
     /* Members */
+    python::declareAlgorithm<SingleFrameAlgorithm>(clsSingleFrameAlgorithm);
+
     clsSimpleAlgorithm.def("measureForced", &SimpleAlgorithm::measureForced,
         "measRecord"_a, "exposure"_a, "refRecord"_a, "refWcs"_a);
 


### PR DESCRIPTION
This change allows Algorithm classes to be passed to methods that expect a `SingleFrameAlgorithm`.