### PR TITLE
DM-9249 Change FlagHandler to remove the enum of flag types

### DIFF
--- a/include/lsst/meas/base/ApertureFlux.h
+++ b/include/lsst/meas/base/ApertureFlux.h
@@ -83,15 +83,13 @@ struct ApertureFluxResult;
 class ApertureFluxAlgorithm : public SimpleAlgorithm {
 public:
 
-    /// @copydoc PsfFluxAlgorithm::FlagBits
-    enum FlagBits {
-        FAILURE=0,
-        APERTURE_TRUNCATED,
-        SINC_COEFFS_TRUNCATED,
-        N_FLAGS
-    };
+    // Structures and routines to manage flaghandler
+    static FlagDefinitionList const & getFlagDefinitions();
+    static unsigned int const N_FLAGS = 3;
+    static FlagDefinition const FAILURE;
+    static FlagDefinition const APERTURE_TRUNCATED;
+    static FlagDefinition const SINC_COEFFS_TRUNCATED;
 
-    /// Typedef to the control object associated with this algorithm, defined above.
     typedef ApertureFluxControl Control;
 
     /// Result object returned by static methods.
@@ -222,7 +220,6 @@ public:
     /**
      *  Return the flag definitions which apply to aperture flux measurements.
      */
-    static std::array<FlagDefinition,ApertureFluxAlgorithm::N_FLAGS> const & getFlagDefinitions();
 
 protected:
 
@@ -254,13 +251,18 @@ private:
 struct ApertureFluxResult : public FluxResult {
 
     /// Return the flag value associated with the given bit
-    bool getFlag(ApertureFluxAlgorithm::FlagBits bit) const { return _flags[bit]; }
+    bool getFlag(unsigned int index) const { return _flags[index]; }
+
+    /// Return the flag value associated with the given flag name
+    bool getFlag(std::string name) const {
+       return _flags[ApertureFluxAlgorithm::getFlagDefinitions().getDefinition(name).number];
+    }
 
     /// Set the flag value associated with the given bit
-    void setFlag(ApertureFluxAlgorithm::FlagBits bit, bool value=true) { _flags[bit] = value; }
+    void setFlag(unsigned int index, bool value=true) { _flags[index] = value; }
 
     /// Clear (i.e. set to false) the flag associated with the given bit
-    void unsetFlag(ApertureFluxAlgorithm::FlagBits bit) { _flags[bit] = false; }
+    void unsetFlag(unsigned int index) { _flags[index] = false; }
 
 private:
     std::bitset<ApertureFluxAlgorithm::N_FLAGS> _flags;

--- a/include/lsst/meas/base/Blendedness.h
+++ b/include/lsst/meas/base/Blendedness.h
@@ -77,12 +77,12 @@ public:
 class BlendednessAlgorithm : public SimpleAlgorithm {
 public:
 
-    enum {
-        FAILURE=FlagHandler::FAILURE,
-        NO_CENTROID,
-        NO_SHAPE,
-        N_FLAGS
-    };
+    // Structures and routines to manage flaghandler
+    static FlagDefinitionList const & getFlagDefinitions();
+    static FlagDefinition const FAILURE;
+    static FlagDefinition const NO_CENTROID;
+    static FlagDefinition const NO_SHAPE;
+
     typedef BlendednessControl Control;
 
     BlendednessAlgorithm(Control const & ctrl, std::string const & name, afw::table::Schema & schema);

--- a/include/lsst/meas/base/GaussianCentroid.h
+++ b/include/lsst/meas/base/GaussianCentroid.h
@@ -86,16 +86,10 @@ public:
 class GaussianCentroidAlgorithm : public SimpleAlgorithm {
 public:
 
-    /**
-     *  @brief Flag bits to be used with the 'flags' data member of the Result object.
-     *
-     *  Inspect getFlagDefinitions() for more detailed explanations of each flag.
-     */
-    enum {
-        FAILURE=FlagHandler::FAILURE,
-        NO_PEAK,
-        N_FLAGS
-    };
+    // Structures and routines to manage flaghandler
+    static FlagDefinitionList const & getFlagDefinitions();
+    static FlagDefinition const FAILURE;
+    static FlagDefinition const NO_PEAK;
 
     /// A typedef to the Control object for this algorithm, defined above.
     /// The control object contains the configuration parameters for this algorithm.

--- a/include/lsst/meas/base/GaussianFlux.h
+++ b/include/lsst/meas/base/GaussianFlux.h
@@ -62,10 +62,9 @@ public:
 class GaussianFluxAlgorithm : public SimpleAlgorithm {
 public:
 
-    enum {
-        FAILURE=FlagHandler::FAILURE,
-        N_FLAGS
-    };
+    // Structures and routines to manage flaghandler
+    static FlagDefinitionList const & getFlagDefinitions();
+    static FlagDefinition const FAILURE;
 
     /// A typedef to the Control object for this algorithm, defined above.
     /// The control object contains the configuration parameters for this algorithm.

--- a/include/lsst/meas/base/NaiveCentroid.h
+++ b/include/lsst/meas/base/NaiveCentroid.h
@@ -66,17 +66,11 @@ public:
 class NaiveCentroidAlgorithm : public SimpleAlgorithm {
 public:
 
-    /**
-     *  @brief Flag bits to be used with the 'flags' data member of the Result object.
-     *
-     *  Inspect getFlagDefinitions() for more detailed explanations of each flag.
-     */
-    enum {
-        FAILURE=FlagHandler::FAILURE,
-        NO_COUNTS,
-        EDGE,
-        N_FLAGS
-    };
+    // Structures and routines to manage flaghandler
+    static FlagDefinitionList const & getFlagDefinitions();
+    static FlagDefinition const FAILURE;
+    static FlagDefinition const NO_COUNTS;
+    static FlagDefinition const EDGE;
 
     typedef NaiveCentroidControl Control;
 

--- a/include/lsst/meas/base/PeakLikelihoodFlux.h
+++ b/include/lsst/meas/base/PeakLikelihoodFlux.h
@@ -71,10 +71,9 @@ public:
 class PeakLikelihoodFluxAlgorithm : public SimpleAlgorithm {
 public:
 
-    enum {
-        FAILURE=FlagHandler::FAILURE,
-        N_FLAGS
-    };
+    // Structures and routines to manage flaghandler
+    static FlagDefinitionList const & getFlagDefinitions();
+    static FlagDefinition const FAILURE;
 
     /// A typedef to the Control object for this algorithm, defined above.
     /// The control object contains the configuration parameters for this algorithm.

--- a/include/lsst/meas/base/PsfFlux.h
+++ b/include/lsst/meas/base/PsfFlux.h
@@ -68,12 +68,11 @@ public:
 class PsfFluxAlgorithm : public SimpleAlgorithm {
 public:
 
-    enum {
-        FAILURE=FlagHandler::FAILURE,
-        NO_GOOD_PIXELS,
-        EDGE,
-        N_FLAGS
-    };
+    // Structures and routines to manage flaghandler
+    static FlagDefinitionList const & getFlagDefinitions();
+    static FlagDefinition const FAILURE;
+    static FlagDefinition const NO_GOOD_PIXELS;
+    static FlagDefinition const EDGE;
 
     /// A typedef to the Control object for this algorithm, defined above.
     /// The control object contains the configuration parameters for this algorithm.

--- a/include/lsst/meas/base/SdssCentroid.h
+++ b/include/lsst/meas/base/SdssCentroid.h
@@ -68,14 +68,13 @@ public:
 class SdssCentroidAlgorithm : public SimpleAlgorithm {
 public:
 
-    enum {
-        FAILURE=FlagHandler::FAILURE,
-        EDGE,
-        NO_SECOND_DERIVATIVE,
-        ALMOST_NO_SECOND_DERIVATIVE,
-        NOT_AT_MAXIMUM,
-        N_FLAGS
-    };
+    // Structures and routines to manage flaghandler
+    static FlagDefinitionList const & getFlagDefinitions();
+    static FlagDefinition const FAILURE;
+    static FlagDefinition const EDGE;
+    static FlagDefinition const NO_SECOND_DERIVATIVE;
+    static FlagDefinition const ALMOST_NO_SECOND_DERIVATIVE;
+    static FlagDefinition const NOT_AT_MAXIMUM;
 
     /// A typedef to the Control object for this algorithm, defined above.
     /// The control object contains the configuration parameters for this algorithm.

--- a/include/lsst/meas/base/SdssShape.h
+++ b/include/lsst/meas/base/SdssShape.h
@@ -152,6 +152,16 @@ private:
 class SdssShapeAlgorithm : public SimpleAlgorithm {
 public:
 
+    // Structures and routines to manage flaghandler
+    static FlagDefinitionList const & getFlagDefinitions();
+    static unsigned int const N_FLAGS = 6;
+    static FlagDefinition const FAILURE;
+    static FlagDefinition const UNWEIGHTED_BAD;
+    static FlagDefinition const UNWEIGHTED;
+    static FlagDefinition const SHIFT;
+    static FlagDefinition const MAXITER;
+    static FlagDefinition const PSF_SHAPE_BAD;
+
     typedef SdssShapeControl Control;
     typedef SdssShapeResult Result;
     typedef SdssShapeResultKey ResultKey;
@@ -160,15 +170,6 @@ public:
     //       doMeasurePsf = true (do set extra fields) or false (do NOT set extra fields), all of
     //       the code in SdssShape assumes that PSF_SHAPE_BAD is the last entry in the enum list.
     //       If new flags are added, be sure to add them above the PSF_SHAPE_BAD entry.
-    enum {
-        FAILURE=FlagHandler::FAILURE,
-        UNWEIGHTED_BAD,
-        UNWEIGHTED,
-        SHIFT,
-        MAXITER,
-        PSF_SHAPE_BAD,  // NOTE: PSF_SHAPE_BAD must be the last entry in the enum list
-        N_FLAGS
-    };
 
     SdssShapeAlgorithm(Control const & ctrl, std::string const & name, afw::table::Schema & schema);
 
@@ -245,7 +246,11 @@ public:
 #endif
 
     /// Flag getter for Swig, which doesn't understand std::bitset
-    bool getFlag(int index) const { return flags[index]; }
+    bool getFlag(unsigned int index) { return flags[index]; }
+
+    bool getFlag(std::string name) {
+       return flags[SdssShapeAlgorithm::getFlagDefinitions().getDefinition(name).number];
+    }
 
     SdssShapeResult(); ///< Constructor; initializes everything to NaN
 

--- a/python/lsst/meas/base/utilities.i
+++ b/python/lsst/meas/base/utilities.i
@@ -22,6 +22,7 @@
  */
 
 %{
+#include <vector>
 #include "lsst/meas/base/FluxUtilities.h"
 #include "lsst/meas/base/CentroidUtilities.h"
 #include "lsst/meas/base/ShapeUtilities.h"
@@ -34,7 +35,6 @@
 
 %immutable lsst::meas::base::FlagDefinition::name;
 %immutable lsst::meas::base::FlagDefinition::doc;
-%template(FlagDefinitionVector) std::vector< lsst::meas::base::FlagDefinition>;
 %declareNumPyConverters(lsst::meas::base::CentroidCov);
 %declareNumPyConverters(lsst::meas::base::ShapeCov);
 %declareNumPyConverters(lsst::meas::base::ShapeTrMatrix);
@@ -50,7 +50,6 @@
 
 %declareFunctorKey(ShapeResult, lsst::meas::base::ShapeResult)
 %shared_ptr(lsst::meas::base::ShapeResultKey)
-
 %include "lsst/meas/base/FluxUtilities.h"
 %include "lsst/meas/base/CentroidUtilities.h"
 %include "lsst/meas/base/ShapeUtilities.h"

--- a/src/ApertureFlux.cc
+++ b/src/ApertureFlux.cc
@@ -34,6 +34,18 @@
 #include "lsst/meas/base/ApertureFlux.h"
 
 namespace lsst { namespace meas { namespace base {
+namespace {
+FlagDefinitionList flagDefinitions;
+} // end anonymous
+
+FlagDefinition const ApertureFluxAlgorithm::FAILURE = flagDefinitions.addFailureFlag();
+FlagDefinition const ApertureFluxAlgorithm::APERTURE_TRUNCATED = flagDefinitions.add("flag_apertureTruncated", "aperture did not fit within measurement image");
+FlagDefinition const ApertureFluxAlgorithm::SINC_COEFFS_TRUNCATED = flagDefinitions.add("flag_sincCoeffsTruncated", "full sinc coefficient image did not fit within measurement image");
+
+FlagDefinitionList const & ApertureFluxAlgorithm::getFlagDefinitions() {
+    return flagDefinitions;
+}
+
 
 ApertureFluxControl::ApertureFluxControl() : radii(10), maxSincRadius(10.0), shiftKernel("lanczos5") {
     // defaults here stolen from HSC pipeline defaults
@@ -43,14 +55,6 @@ ApertureFluxControl::ApertureFluxControl() : radii(10), maxSincRadius(10.0), shi
     std::copy(defaultRadii.begin(), defaultRadii.end(), radii.begin());
 }
 
-std::array<FlagDefinition,ApertureFluxAlgorithm::N_FLAGS> const & ApertureFluxAlgorithm::getFlagDefinitions() {
-    static std::array<FlagDefinition,ApertureFluxAlgorithm::N_FLAGS> flagDefs = {{
-        {"flag", "general failure flag"},
-        {"flag_apertureTruncated", "aperture did not fit within measurement image"},
-        {"flag_sincCoeffsTruncated", "full sinc coefficient image did not fit within measurement image"}
-    }};
-    return flagDefs;
-}
 
 std::string ApertureFluxAlgorithm::makeFieldPrefix(std::string const & name, double radius) {
     std::string prefix = (boost::format("%s_%.1f") % name % radius).str();
@@ -62,11 +66,12 @@ ApertureFluxAlgorithm::Keys::Keys(
 ) :
     fluxKey(FluxResultKey::addFields(schema, prefix, doc)),
     flags(
-        FlagHandler::addFields(
-            schema, prefix,
-            ApertureFluxAlgorithm::getFlagDefinitions().begin(),
-            ApertureFluxAlgorithm::getFlagDefinitions().begin() + (isSinc ? 3 : 2)
-        )
+           //  The exclusion List can either be empty, or constain the sinc coeffs flag
+            FlagHandler::addFields(
+                schema, prefix,
+                ApertureFluxAlgorithm::getFlagDefinitions(),
+                isSinc ? FlagDefinitionList() : FlagDefinitionList({{SINC_COEFFS_TRUNCATED}})
+            )
     )
 {}
 
@@ -103,14 +108,14 @@ void ApertureFluxAlgorithm::copyResultToRecord(
     int index
 ) const {
     record.set(_keys[index].fluxKey, result);
-    if (result.getFlag(FAILURE)) {
-        _keys[index].flags.setValue(record, FAILURE, true);
+    if (result.getFlag(FAILURE.number)) {
+        _keys[index].flags.setValue(record, FAILURE.number, true);
     }
-    if (result.getFlag(APERTURE_TRUNCATED)) {
-        _keys[index].flags.setValue(record, APERTURE_TRUNCATED, true);
+    if (result.getFlag(APERTURE_TRUNCATED.number)) {
+        _keys[index].flags.setValue(record, APERTURE_TRUNCATED.number, true);
     }
-    if (result.getFlag(SINC_COEFFS_TRUNCATED)) {
-        _keys[index].flags.setValue(record, SINC_COEFFS_TRUNCATED, true);
+    if (result.getFlag(SINC_COEFFS_TRUNCATED.number)) {
+        _keys[index].flags.setValue(record, SINC_COEFFS_TRUNCATED.number, true);
     }
 }
 
@@ -137,14 +142,14 @@ CONST_PTR(afw::image::Image<T>) getSincCoeffs(
         // but since that's much larger than the aperture (and close
         // to zero outside the aperture), it may not be a serious
         // problem.
-        result.setFlag(ApertureFluxAlgorithm::SINC_COEFFS_TRUNCATED);
+        result.setFlag(ApertureFluxAlgorithm::SINC_COEFFS_TRUNCATED.number);
         afw::geom::Box2I overlap = cImage->getBBox();
         overlap.clip(bbox);
         if (!overlap.contains(afw::geom::Box2I(ellipse.computeBBox()))) {
             // The clipping was indeed serious, as we we did have to clip within
             // the aperture; can't expect any decent answer at this point.
-            result.setFlag(ApertureFluxAlgorithm::APERTURE_TRUNCATED);
-            result.setFlag(ApertureFluxAlgorithm::FAILURE);
+            result.setFlag(ApertureFluxAlgorithm::APERTURE_TRUNCATED.number);
+            result.setFlag(ApertureFluxAlgorithm::FAILURE.number);
         }
         cImage = std::make_shared< afw::image::Image<T> >(*cImage, overlap);
     }
@@ -161,7 +166,7 @@ ApertureFluxAlgorithm::Result ApertureFluxAlgorithm::computeSincFlux(
 ) {
     Result result;
     CONST_PTR(afw::image::Image<T>) cImage = getSincCoeffs<T>(image.getBBox(), ellipse, result, ctrl);
-    if (result.getFlag(APERTURE_TRUNCATED)) return result;
+    if (result.getFlag(APERTURE_TRUNCATED.number)) return result;
     afw::image::Image<T> subImage(image, cImage->getBBox());
     result.flux = (subImage.getArray().template asEigen<Eigen::ArrayXpr>()
                    * cImage->getArray().template asEigen<Eigen::ArrayXpr>()).sum();
@@ -176,7 +181,7 @@ ApertureFluxAlgorithm::Result ApertureFluxAlgorithm::computeSincFlux(
 ) {
     Result result;
     CONST_PTR(afw::image::Image<T>) cImage = getSincCoeffs<T>(image.getBBox(), ellipse, result, ctrl);
-    if (result.getFlag(APERTURE_TRUNCATED)) return result;
+    if (result.getFlag(APERTURE_TRUNCATED.number)) return result;
     afw::image::MaskedImage<T> subImage(image, cImage->getBBox(afw::image::PARENT), afw::image::PARENT);
     result.flux = (subImage.getImage()->getArray().template asEigen<Eigen::ArrayXpr>()
                    * cImage->getArray().template asEigen<Eigen::ArrayXpr>()).sum();
@@ -196,8 +201,8 @@ ApertureFluxAlgorithm::Result ApertureFluxAlgorithm::computeNaiveFlux(
     Result result;
     afw::geom::ellipses::PixelRegion region(ellipse); // behaves mostly like a Footprint
     if (!image.getBBox().contains(region.getBBox())) {
-        result.setFlag(APERTURE_TRUNCATED);
-        result.setFlag(FAILURE);
+        result.setFlag(APERTURE_TRUNCATED.number);
+        result.setFlag(FAILURE.number);
         return result;
     }
     result.flux = 0;
@@ -224,8 +229,8 @@ ApertureFluxAlgorithm::Result ApertureFluxAlgorithm::computeNaiveFlux(
     Result result;
     afw::geom::ellipses::PixelRegion region(ellipse); // behaves mostly like a Footprint
     if (!image.getBBox().contains(region.getBBox())) {
-        result.setFlag(APERTURE_TRUNCATED);
-        result.setFlag(FAILURE);
+        result.setFlag(APERTURE_TRUNCATED.number);
+        result.setFlag(FAILURE.number);
         return result;
     }
     result.flux = 0.0;
@@ -322,12 +327,14 @@ ApertureFluxTransform::ApertureFluxTransform(
     _ctrl(ctrl)
 {
     for (std::size_t i = 0; i < _ctrl.radii.size(); ++i) {
-        for (auto flag = ApertureFluxAlgorithm::getFlagDefinitions().begin();
-            flag < ApertureFluxAlgorithm::getFlagDefinitions().begin() +
-                   (_ctrl.radii[i] <= _ctrl.maxSincRadius ? 3 : 2); flag++) {
+        for (std::size_t j = 0; j < ApertureFluxAlgorithm::getFlagDefinitions().size(); j++) {
+            FlagDefinition const & flag = ApertureFluxAlgorithm::getFlagDefinitions()[j];
+            if (_ctrl.radii[i] > _ctrl.maxSincRadius && flag == ApertureFluxAlgorithm::SINC_COEFFS_TRUNCATED) {
+                continue;
+            } 
             mapper.addMapping(mapper.getInputSchema().find<afw::table::Flag>((boost::format("%s_%s") %
                               ApertureFluxAlgorithm::makeFieldPrefix(name, _ctrl.radii[i]) %
-                              flag->name).str()).key);
+                              flag.name).str()).key);
         }
         _magKeys.push_back(MagResultKey::addFields(mapper.editOutputSchema(),
                            ApertureFluxAlgorithm::makeFieldPrefix(name, _ctrl.radii[i])));

--- a/src/GaussianFlux.cc
+++ b/src/GaussianFlux.cc
@@ -33,6 +33,16 @@
 #include "lsst/meas/base/SdssShape.h"
 
 namespace lsst { namespace meas { namespace base {
+namespace {
+FlagDefinitionList flagDefinitions;
+} // end anonymous
+
+FlagDefinition const GaussianFluxAlgorithm::FAILURE = flagDefinitions.addFailureFlag();
+
+FlagDefinitionList const & GaussianFluxAlgorithm::getFlagDefinitions() {
+    return flagDefinitions;
+}
+
 
 GaussianFluxAlgorithm::GaussianFluxAlgorithm(
     Control const & ctrl,
@@ -45,10 +55,7 @@ GaussianFluxAlgorithm::GaussianFluxAlgorithm(
     _centroidExtractor(schema, name),
     _shapeExtractor(schema, name)
 {
-    static std::array<FlagDefinition,N_FLAGS> const flagDefs = {{
-        {"flag", "general failure flag, set if anything went wrong"}
-    }};
-    _flagHandler = FlagHandler::addFields(schema, name, flagDefs.begin(), flagDefs.end());
+    _flagHandler = FlagHandler::addFields(schema, name, getFlagDefinitions());
 }
 
 void GaussianFluxAlgorithm::measure(
@@ -63,7 +70,7 @@ void GaussianFluxAlgorithm::measure(
     );
 
     measRecord.set(_fluxResultKey, result);
-    _flagHandler.setValue(measRecord, FAILURE, false);
+    _flagHandler.setValue(measRecord, FAILURE.number, false);
 }
 
 

--- a/src/InputUtilities.cc
+++ b/src/InputUtilities.cc
@@ -126,13 +126,13 @@ afw::geom::Point2D SafeCentroidExtractor::operator()(
         result = extractPeak(record, _name);
         if (!_isCentroider) {
             // set the general flag, because using the Peak might affect the current measurement
-            flags.setValue(record, FlagHandler::FAILURE, true);
+            flags.setValue(record, flags.getFailureFlagNumber(), true);
         }
     } else if (!_isCentroider && record.getTable()->getCentroidFlagKey().isValid()
                && record.getCentroidFlag()) {
         // we got a usable value, but the centroid flag is still be set, and that might affect
         // the current measurement
-        flags.setValue(record, FlagHandler::FAILURE, true);
+        flags.setValue(record, flags.getFailureFlagNumber(), true);
     }
     return result;
 }
@@ -193,12 +193,12 @@ afw::geom::ellipses::Quadrupole SafeShapeExtractor::operator()(
         throw LSST_EXCEPT(
             MeasurementError,
             (boost::format("%s: Shape needed, and Shape slot measurement failed.") % _name).str(),
-            FlagHandler::FAILURE
+            flags.getFailureFlagNumber() 
         );
     } else if (record.getTable()->getShapeFlagKey().isValid() && record.getShapeFlag()) {
         // we got a usable value, but the shape flag might still be set, and that might affect
         // the current measurement
-        flags.setValue(record, FlagHandler::FAILURE, true);
+        flags.setValue(record, flags.getFailureFlagNumber(), true);
     }
     return result;
 }

--- a/src/PeakLikelihoodFlux.cc
+++ b/src/PeakLikelihoodFlux.cc
@@ -34,6 +34,16 @@
 #include "lsst/afw/table/Source.h"
 
 namespace lsst { namespace meas { namespace base {
+namespace {
+FlagDefinitionList flagDefinitions;
+} // end anonymous
+
+FlagDefinition const PeakLikelihoodFluxAlgorithm::FAILURE = flagDefinitions.addFailureFlag();
+
+FlagDefinitionList const & PeakLikelihoodFluxAlgorithm::getFlagDefinitions() {
+    return flagDefinitions;
+}
+
 
 namespace {
 
@@ -182,10 +192,7 @@ PeakLikelihoodFluxAlgorithm::PeakLikelihoodFluxAlgorithm(
     ),
     _centroidExtractor(schema, name)
 {
-    static std::array<FlagDefinition,N_FLAGS> const flagDefs = {{
-        {"flag", "general failure flag, set if anything went wrong"}
-    }};
-    _flagHandler = FlagHandler::addFields(schema, name, flagDefs.begin(), flagDefs.end());
+    _flagHandler = FlagHandler::addFields(schema, name, getFlagDefinitions());
 }
 
 void PeakLikelihoodFluxAlgorithm::measure(
@@ -248,7 +255,7 @@ void PeakLikelihoodFluxAlgorithm::measure(
     result.flux = flux;
     result.fluxSigma = std::sqrt(var);
     measRecord.set(_fluxResultKey, result);
-    _flagHandler.setValue(measRecord, FAILURE, false);
+    _flagHandler.setValue(measRecord, FAILURE.number, false);
 
 }
 

--- a/src/SdssCentroid.cc
+++ b/src/SdssCentroid.cc
@@ -34,6 +34,20 @@
 
 
 namespace lsst { namespace meas { namespace base {
+namespace {
+FlagDefinitionList flagDefinitions;
+} // end anonymous
+
+FlagDefinition const SdssCentroidAlgorithm::FAILURE = flagDefinitions.addFailureFlag();
+FlagDefinition const SdssCentroidAlgorithm::EDGE = flagDefinitions.add("flag_edge", "Object too close to edge");
+FlagDefinition const SdssCentroidAlgorithm::NO_SECOND_DERIVATIVE = flagDefinitions.add("flag_noSecondDerivative", "Vanishing second derivative");
+FlagDefinition const SdssCentroidAlgorithm::ALMOST_NO_SECOND_DERIVATIVE = flagDefinitions.add("flag_almostNoSecondDerivative", "Almost vanishing second derivative");
+FlagDefinition const SdssCentroidAlgorithm::NOT_AT_MAXIMUM = flagDefinitions.add("flag_notAtMaximum", "Object is not at a maximum");
+
+FlagDefinitionList const & SdssCentroidAlgorithm::getFlagDefinitions() {
+    return flagDefinitions;
+}
+
 
 namespace {
 
@@ -136,16 +150,16 @@ void doMeasureCentroidImpl(double *xCenter, // output; x-position of object
     if (d2x == 0.0 || d2y == 0.0) {
         throw LSST_EXCEPT(
             MeasurementError,
-            flagHandler.getDefinition(SdssCentroidAlgorithm::NO_SECOND_DERIVATIVE).doc,
-            SdssCentroidAlgorithm::NO_SECOND_DERIVATIVE
+            SdssCentroidAlgorithm::NO_SECOND_DERIVATIVE.doc,
+            SdssCentroidAlgorithm::NO_SECOND_DERIVATIVE.number
         );
     }
     if (d2x < 0.0 || d2y < 0.0) {
         throw LSST_EXCEPT(
             MeasurementError,
-            flagHandler.getDefinition(SdssCentroidAlgorithm::NOT_AT_MAXIMUM).doc +
+            SdssCentroidAlgorithm::NOT_AT_MAXIMUM.doc +
                 (boost::format(": d2I/dx2, d2I/dy2 = %g %g") % d2x % d2y).str(),
-            SdssCentroidAlgorithm::NOT_AT_MAXIMUM
+            SdssCentroidAlgorithm::NOT_AT_MAXIMUM.number
         );
     }
 
@@ -155,9 +169,9 @@ void doMeasureCentroidImpl(double *xCenter, // output; x-position of object
     if (fabs(dx0) > 10.0 || fabs(dy0) > 10.0) {
         throw LSST_EXCEPT(
             MeasurementError,
-            flagHandler.getDefinition(SdssCentroidAlgorithm::ALMOST_NO_SECOND_DERIVATIVE).doc +
+            SdssCentroidAlgorithm::ALMOST_NO_SECOND_DERIVATIVE.doc +
                 (boost::format(": sx, d2x, sy, d2y = %f %f %f %f") % sx % d2x % sy % d2y).str(),
-            SdssCentroidAlgorithm::ALMOST_NO_SECOND_DERIVATIVE
+            SdssCentroidAlgorithm::ALMOST_NO_SECOND_DERIVATIVE.number
         );
     }
 
@@ -258,17 +272,17 @@ void doMeasureCentroidImpl(double *xCenter, // output; x-position of object
     if (d2x == 0.0 || d2y == 0.0) {
         throw LSST_EXCEPT(
             MeasurementError,
-            flagHandler.getDefinition(SdssCentroidAlgorithm::NO_SECOND_DERIVATIVE).doc,
-            SdssCentroidAlgorithm::NO_SECOND_DERIVATIVE
+            SdssCentroidAlgorithm::NO_SECOND_DERIVATIVE.doc,
+            SdssCentroidAlgorithm::NO_SECOND_DERIVATIVE.number
         );
     }
    if ((!negative && (d2x < 0.0 || d2y < 0.0)) ||
         ( negative && (d2x > 0.0 || d2y > 0.0))) {
         throw LSST_EXCEPT(
             MeasurementError,
-            flagHandler.getDefinition(SdssCentroidAlgorithm::NOT_AT_MAXIMUM).doc +
+            SdssCentroidAlgorithm::NOT_AT_MAXIMUM.doc +
                 (boost::format(": d2I/dx2, d2I/dy2 = %g %g") % d2x % d2y).str(),
-            SdssCentroidAlgorithm::NOT_AT_MAXIMUM
+            SdssCentroidAlgorithm::NOT_AT_MAXIMUM.number
         );
     }
 
@@ -278,9 +292,9 @@ void doMeasureCentroidImpl(double *xCenter, // output; x-position of object
     if (fabs(dx0) > 10.0 || fabs(dy0) > 10.0) {
         throw LSST_EXCEPT(
             MeasurementError,
-            flagHandler.getDefinition(SdssCentroidAlgorithm::NO_SECOND_DERIVATIVE).doc +
+            SdssCentroidAlgorithm::NO_SECOND_DERIVATIVE.doc +
                 (boost::format(": sx, d2x, sy, d2y = %f %f %f %f") % sx % d2x % sy % d2y).str(),
-            SdssCentroidAlgorithm::ALMOST_NO_SECOND_DERIVATIVE
+            SdssCentroidAlgorithm::ALMOST_NO_SECOND_DERIVATIVE.number
         );
     }
 
@@ -391,8 +405,8 @@ smoothAndBinImage(CONST_PTR(lsst::afw::detection::Psf) psf,
     } catch (pex::exceptions::LengthError & err) {
         throw LSST_EXCEPT(
             MeasurementError,
-            _flagHandler.getDefinition(SdssCentroidAlgorithm::EDGE).doc,
-            SdssCentroidAlgorithm::EDGE
+            SdssCentroidAlgorithm::EDGE.doc,
+            SdssCentroidAlgorithm::EDGE.number
         );
     }
     PTR(MaskedImageT) binnedImage = lsst::afw::math::binImage(*subImage, binX, binY, lsst::afw::math::MEAN);
@@ -409,16 +423,6 @@ smoothAndBinImage(CONST_PTR(lsst::afw::detection::Psf) psf,
     return std::make_pair(smoothedImage, smoothingSigma);
 }
 
-std::array<FlagDefinition,SdssCentroidAlgorithm::N_FLAGS> const & getFlagDefinitions() {
-    static std::array<FlagDefinition,SdssCentroidAlgorithm::N_FLAGS> const flagDefs = {{
-        {"flag", "general failure flag, set if anything went wrong"},
-        {"flag_edge", "Object too close to edge"},
-        {"flag_noSecondDerivative", "Vanishing second derivative"},
-        {"flag_almostNoSecondDerivative", "Almost vanishing second derivative"},
-        {"flag_notAtMaximum", "Object is not at a maximum"}
-    }};
-    return flagDefs;
-}
 
 }  // end anonymous namespace
 
@@ -431,7 +435,7 @@ SdssCentroidAlgorithm::SdssCentroidAlgorithm(
         CentroidResultKey::addFields(schema, name, "centroid from Sdss Centroid algorithm", SIGMA_ONLY)
     ),
     _flagHandler(FlagHandler::addFields(schema, name,
-                                          getFlagDefinitions().begin(), getFlagDefinitions().end())),
+                                          getFlagDefinitions())),
     _centroidExtractor(schema, name, true),
     _centroidChecker(schema, name, ctrl.doFootprintCheck, ctrl.maxDistToPeak)
 {   
@@ -466,8 +470,8 @@ void SdssCentroidAlgorithm::measure(
     if (!image.getBBox().contains(lsst::afw::geom::Extent2I(x,y) + image.getXY0())) {
             throw LSST_EXCEPT(
             lsst::meas::base::MeasurementError,
-            _flagHandler.getDefinition(EDGE).doc,
-            EDGE
+            EDGE.doc,
+            EDGE.number
         );
     }
 
@@ -550,9 +554,14 @@ SdssCentroidTransform::SdssCentroidTransform(
 ) :
     CentroidTransform{name, mapper}
 {
-    for (auto flag = getFlagDefinitions().begin() + 1; flag < getFlagDefinitions().end(); ++flag) {
-        mapper.addMapping(mapper.getInputSchema().find<afw::table::Flag>(
-                          mapper.getInputSchema().join(name, flag->name)).key);
+    for (std::size_t i = 0; i < SdssCentroidAlgorithm::getFlagDefinitions().size(); i++) {
+        FlagDefinition const & flag = SdssCentroidAlgorithm::getFlagDefinitions()[i];
+        if (flag == SdssCentroidAlgorithm::FAILURE) continue;
+        if (mapper.getInputSchema().getNames().count(
+            mapper.getInputSchema().join(name, flag.name)) == 0) continue;
+        afw::table::Key<afw::table::Flag> key = mapper.getInputSchema().find<afw::table::Flag>(
+            name + "_" + flag.name).key;
+        mapper.addMapping(key);
     }
 }
 

--- a/src/SdssShape.cc
+++ b/src/SdssShape.cc
@@ -42,9 +42,22 @@ namespace afwImage = lsst::afw::image;
 namespace afwGeom = lsst::afw::geom;
 namespace afwTable = lsst::afw::table;
 
-namespace lsst {
-namespace meas {
-namespace base {
+namespace lsst { namespace meas { namespace base {
+namespace {
+FlagDefinitionList flagDefinitions;
+} // end anonymous
+
+FlagDefinition const SdssShapeAlgorithm::FAILURE = flagDefinitions.addFailureFlag();
+FlagDefinition const SdssShapeAlgorithm::UNWEIGHTED_BAD = flagDefinitions.add("flag_unweightedBad", "Both weighted and unweighted moments were invalid");
+FlagDefinition const SdssShapeAlgorithm::UNWEIGHTED = flagDefinitions.add("flag_unweighted", "Weighted moments converged to an invalid value; using unweighted moments");
+FlagDefinition const SdssShapeAlgorithm::SHIFT = flagDefinitions.add("flag_shift", "centroid shifted by more than the maximum allowed amount");
+FlagDefinition const SdssShapeAlgorithm::MAXITER = flagDefinitions.add("flag_maxIter", "Too many iterations in adaptive moments");
+FlagDefinition const SdssShapeAlgorithm::PSF_SHAPE_BAD = flagDefinitions.add("flag_psf", "Failure in measuring PSF model shape");
+
+FlagDefinitionList const & SdssShapeAlgorithm::getFlagDefinitions() {
+    return flagDefinitions;
+}
+
 
 namespace {  // anonymous
 
@@ -415,7 +428,7 @@ bool getAdaptiveMoments(ImageT const& mimage, double bkgd, double xcen, double y
 
     if (std::isnan(xcen) || std::isnan(ycen)) {
         // Can't do anything
-        shape->flags[SdssShapeAlgorithm::UNWEIGHTED_BAD] = true;
+        shape->flags[SdssShapeAlgorithm::UNWEIGHTED_BAD.number] = true;
         return false;
     }
 
@@ -428,7 +441,7 @@ bool getAdaptiveMoments(ImageT const& mimage, double bkgd, double xcen, double y
         std::tuple<std::pair<bool, double>, double, double, double> weights =
             getWeights(sigma11W, sigma12W, sigma22W);
         if (!std::get<0>(weights).first) {
-            shape->flags[SdssShapeAlgorithm::UNWEIGHTED] = true;
+            shape->flags[SdssShapeAlgorithm::UNWEIGHTED.number] = true;
             break;
         }
 
@@ -465,7 +478,7 @@ bool getAdaptiveMoments(ImageT const& mimage, double bkgd, double xcen, double y
 
         if (calcmom<false>(image, xcen, ycen, bbox, bkgd, interpflag, w11, w12, w22,
                            &I0, &sum, &sumx, &sumy, &sumxx, &sumxy, &sumyy, &sums4, negative) < 0) {
-            shape->flags[SdssShapeAlgorithm::UNWEIGHTED] = true;
+            shape->flags[SdssShapeAlgorithm::UNWEIGHTED.number] = true;
             break;
         }
 
@@ -482,7 +495,7 @@ bool getAdaptiveMoments(ImageT const& mimage, double bkgd, double xcen, double y
         shape->y = sumy/sum;
 
         if (fabs(shape->x - xcen0) > shiftmax || fabs(shape->y - ycen0) > shiftmax) {
-            shape->flags[SdssShapeAlgorithm::SHIFT] = true;
+            shape->flags[SdssShapeAlgorithm::SHIFT.number] = true;
         }
 /*
  * OK, we have the centre. Proceed to find the second moments.
@@ -492,7 +505,7 @@ bool getAdaptiveMoments(ImageT const& mimage, double bkgd, double xcen, double y
         float const sigma12_ow = sumxy/sum; //                 xx, xy, and yy
 
         if (sigma11_ow <= 0 || sigma22_ow <= 0) {
-            shape->flags[SdssShapeAlgorithm::UNWEIGHTED] = true;
+            shape->flags[SdssShapeAlgorithm::UNWEIGHTED.number] = true;
             break;
         }
 
@@ -540,7 +553,7 @@ bool getAdaptiveMoments(ImageT const& mimage, double bkgd, double xcen, double y
             std::tuple<std::pair<bool, double>, double, double, double> weights =
                 getWeights(sigma11_ow, sigma12_ow, sigma22_ow);
             if (!std::get<0>(weights).first) {
-                shape->flags[SdssShapeAlgorithm::UNWEIGHTED] = true;
+                shape->flags[SdssShapeAlgorithm::UNWEIGHTED.number] = true;
                 break;
             }
 
@@ -555,7 +568,7 @@ bool getAdaptiveMoments(ImageT const& mimage, double bkgd, double xcen, double y
             weights = getWeights(n11, n12, n22);
             if (!std::get<0>(weights).first) {
                 // product-of-Gaussians assumption failed
-                shape->flags[SdssShapeAlgorithm::UNWEIGHTED] = true;
+                shape->flags[SdssShapeAlgorithm::UNWEIGHTED.number] = true;
                 break;
             }
 
@@ -565,29 +578,29 @@ bool getAdaptiveMoments(ImageT const& mimage, double bkgd, double xcen, double y
         }
 
         if (sigma11W <= 0 || sigma22W <= 0) {
-            shape->flags[SdssShapeAlgorithm::UNWEIGHTED] = true;
+            shape->flags[SdssShapeAlgorithm::UNWEIGHTED.number] = true;
             break;
         }
     }
 
     if (iter == maxIter) {
-        shape->flags[SdssShapeAlgorithm::UNWEIGHTED] = true;
-        shape->flags[SdssShapeAlgorithm::MAXITER] = true;
+        shape->flags[SdssShapeAlgorithm::UNWEIGHTED.number] = true;
+        shape->flags[SdssShapeAlgorithm::MAXITER.number] = true;
     }
 
     if (sumxx + sumyy == 0.0) {
-        shape->flags[SdssShapeAlgorithm::UNWEIGHTED] = true;
+        shape->flags[SdssShapeAlgorithm::UNWEIGHTED.number] = true;
     }
 /*
  * Problems; try calculating the un-weighted moments
  */
-    if (shape->flags[SdssShapeAlgorithm::UNWEIGHTED]) {
+    if (shape->flags[SdssShapeAlgorithm::UNWEIGHTED.number]) {
         w11 = w22 = w12 = 0;
         if (calcmom<false>(image, xcen, ycen, bbox, bkgd, interpflag, w11, w12, w22,
                            &I0, &sum, &sumx, &sumy, &sumxx, &sumxy, &sumyy, NULL, negative) < 0 ||
 	    (!negative && sum <= 0) || (negative && sum >= 0)) {
-            shape->flags[SdssShapeAlgorithm::UNWEIGHTED] = false;
-            shape->flags[SdssShapeAlgorithm::UNWEIGHTED_BAD] = true;
+            shape->flags[SdssShapeAlgorithm::UNWEIGHTED.number] = false;
+            shape->flags[SdssShapeAlgorithm::UNWEIGHTED_BAD.number] = true;
 
             if (sum > 0) {
                 shape->xx = 1/12.0;      // a single pixel
@@ -617,7 +630,7 @@ bool getAdaptiveMoments(ImageT const& mimage, double bkgd, double xcen, double y
                 ImageAdaptor<ImageT>().getVariance(mimage, ix, iy); // XXX Overestimate as it includes object
 
             if (bkgd_var > 0.0) {                                   // NaN is not > 0.0
-                if (!(shape->flags[SdssShapeAlgorithm::UNWEIGHTED])) {
+                if (!(shape->flags[SdssShapeAlgorithm::UNWEIGHTED.number])) {
                     Matrix4d fisher = calc_fisher(*shape, bkgd_var); // Fisher matrix
                     Matrix4d cov = fisher.inverse();
                     // convention in afw::geom::ellipses is to order moments (xx, yy, xy),
@@ -650,14 +663,6 @@ SdssShapeResult::SdssShapeResult() :
     flux_xy_Cov(std::numeric_limits<ErrElement>::quiet_NaN())
 {}
 
-static std::array<FlagDefinition,SdssShapeAlgorithm::N_FLAGS> const flagDefs = {{
-        {"flag", "general failure flag, set if anything went wrong"},
-        {"flag_unweightedBad", "Both weighted and unweighted moments were invalid"},
-        {"flag_unweighted", "Weighted moments converged to an invalid value; using unweighted moments"},
-        {"flag_shift", "centroid shifted by more than the maximum allowed amount"},
-        {"flag_maxIter", "Too many iterations in adaptive moments"},
-        {"flag_psf", "Failure in measuring PSF model shape"}
-    }};
 
 SdssShapeResultKey SdssShapeResultKey::addFields(
     afw::table::Schema & schema,
@@ -700,10 +705,14 @@ SdssShapeResultKey SdssShapeResultKey::addFields(
         "count*pixel^2"
     );
 
-    // Skip the last flag if not recording the PSF shape.
-    r._flagHandler = FlagHandler::addFields(schema, name, flagDefs.begin(),
-                                            flagDefs.end() - (r._includePsf ? 0 : 1));
-
+    // Skip the psf flag if not recording the PSF shape.
+    if (r._includePsf) {
+        r._flagHandler = FlagHandler::addFields(schema, name, SdssShapeAlgorithm::getFlagDefinitions());
+    }
+    else {
+        r._flagHandler = FlagHandler::addFields(schema, name, SdssShapeAlgorithm::getFlagDefinitions(),
+                            {SdssShapeAlgorithm::PSF_SHAPE_BAD});
+    }
     return r;
 }
 
@@ -718,10 +727,10 @@ SdssShapeResultKey::SdssShapeResultKey(afw::table::SubSchema const & s) :
     // The input SubSchema may optionally provide for a PSF.
     try {
         _psfShapeResult = afwTable::QuadrupoleKey(s["psf"]);
-        _flagHandler = FlagHandler(s, flagDefs.begin(), flagDefs.end());
+        _flagHandler = FlagHandler(s, SdssShapeAlgorithm::getFlagDefinitions());
         _includePsf = true;
     } catch (pex::exceptions::NotFoundError& e) {
-        _flagHandler = FlagHandler(s, flagDefs.begin(), flagDefs.end() - 1);
+        _flagHandler = FlagHandler(s, SdssShapeAlgorithm::getFlagDefinitions(), {SdssShapeAlgorithm::PSF_SHAPE_BAD});
         _includePsf = false;
     }
 }
@@ -734,7 +743,8 @@ SdssShapeResult SdssShapeResultKey::get(afw::table::BaseRecord const & record) c
     result.flux_xx_Cov = record.get(_flux_xx_Cov);
     result.flux_yy_Cov = record.get(_flux_yy_Cov);
     result.flux_xy_Cov = record.get(_flux_xy_Cov);
-    for (int n = 0; n < SdssShapeAlgorithm::N_FLAGS - (_includePsf ? 0 : 1); ++n) {
+    for (size_t n = 0; n < SdssShapeAlgorithm::N_FLAGS; ++n) {
+        if (n == SdssShapeAlgorithm::PSF_SHAPE_BAD.number && !_includePsf) continue;
         result.flags[n] = _flagHandler.getValue(record, n);
     }
     return result;
@@ -751,7 +761,8 @@ void SdssShapeResultKey::set(afw::table::BaseRecord & record, SdssShapeResult co
     record.set(_flux_xx_Cov, value.flux_xx_Cov);
     record.set(_flux_yy_Cov, value.flux_yy_Cov);
     record.set(_flux_xy_Cov, value.flux_xy_Cov);
-    for (int n = 0; n < SdssShapeAlgorithm::N_FLAGS - (_includePsf ? 0 : 1); ++n) {
+    for (size_t n = 0; n < SdssShapeAlgorithm::N_FLAGS; ++n) {
+        if (n == SdssShapeAlgorithm::PSF_SHAPE_BAD.number && !_includePsf) continue;
         _flagHandler.setValue(record, n, value.flags[n]);
     }
 }
@@ -815,17 +826,17 @@ SdssShapeResult SdssShapeAlgorithm::computeAdaptiveMoments(
 
     SdssShapeResult result;
     try {
-        result.flags[FAILURE] = !getAdaptiveMoments(
+        result.flags[FAILURE.number] = !getAdaptiveMoments(
             image, control.background, xcen, ycen, shiftmax, &result,
             control.maxIter, control.tol1, control.tol2, negative
         );
     } catch (pex::exceptions::Exception & err) {
-        result.flags[FAILURE] = true;
+        result.flags[FAILURE.number] = true;
     }
-    if (result.flags[UNWEIGHTED] || result.flags[SHIFT]) {
+    if (result.flags[UNWEIGHTED.number] || result.flags[SHIFT.number]) {
         // These are also considered fatal errors in terms of the quality of the results,
         // even though they do produce some results.
-        result.flags[FAILURE] = true;
+        result.flags[FAILURE.number] = true;
     }
     if (result.getQuadrupole().getIxx()*result.getQuadrupole().getIyy() <
             (1.0 + 1.0e-6)*result.getQuadrupole().getIxy()*result.getQuadrupole().getIxy())
@@ -833,7 +844,7 @@ SdssShapeResult SdssShapeAlgorithm::computeAdaptiveMoments(
                   // value of epsilon used here is a magic number. DM-5801 is supposed to figure out if we are
                   // to keep this value.
         {
-        if (!result.flags[FAILURE]) {
+        if (!result.flags[FAILURE.number]) {
             throw LSST_EXCEPT(
                 pex::exceptions::LogicError,
                 "Should not get singular moments unless a flag is set");
@@ -940,12 +951,12 @@ void SdssShapeAlgorithm::measure(
         try {
             PTR(afw::detection::Psf const) psf = exposure.getPsf();
             if (!psf) {
-                result.flags[PSF_SHAPE_BAD] = true;
+                result.flags[PSF_SHAPE_BAD.number] = true;
             } else {
                 _resultKey.setPsfShape(measRecord, psf->computeShape(afw::geom::Point2D(result.x, result.y)));
             }
         } catch (pex::exceptions::Exception & err) {
-            result.flags[PSF_SHAPE_BAD] = true;
+            result.flags[PSF_SHAPE_BAD.number] = true;
         }
     }
 
@@ -993,9 +1004,14 @@ SdssShapeTransform::SdssShapeTransform(
     _transformPsf = mapper.getInputSchema().getNames().count("sdssShape_flag_psf") ? true : false;
 
     // Skip the last flag if not transforming the PSF shape.
-    for (auto flag = flagDefs.begin() + 1; flag < flagDefs.end() - (_transformPsf ? 0 : 1); flag++) {
-        mapper.addMapping(mapper.getInputSchema().find<afw::table::Flag>(
-                          mapper.getInputSchema().join(name, flag->name)).key);
+    for (std::size_t i = 0; i < SdssShapeAlgorithm::getFlagDefinitions().size(); i++) {
+        FlagDefinition const & flag = SdssShapeAlgorithm::getFlagDefinitions()[i];
+        if (flag == SdssShapeAlgorithm::FAILURE) continue;
+        if (mapper.getInputSchema().getNames().count(
+            mapper.getInputSchema().join(name, flag.name)) == 0) continue;
+        afw::table::Key<afw::table::Flag> key = mapper.getInputSchema().find<afw::table::Flag>(
+            name + "_" + flag.name).key;
+        mapper.addMapping(key);
     }
 
     _outShapeKey = ShapeResultKey::addFields(mapper.editOutputSchema(), name, "Shape in celestial moments",

--- a/tests/SillyCentroid.h
+++ b/tests/SillyCentroid.h
@@ -60,13 +60,6 @@ public:
      *
      *  Inspect getFlagDefinitions() for more detailed explanations of each flag.
      */
-    enum {
-        FAILURE=lsst::meas::base::FlagHandler::FAILURE,
-        NO_COUNTS,
-        EDGE,
-        N_FLAGS
-    };
-
     typedef SillyCentroidControl Control;
 
     SillyCentroidAlgorithm(
@@ -80,13 +73,12 @@ public:
         ),
         _centroidExtractor(schema, name, true)
     {
-        static std::array<lsst::meas::base::FlagDefinition,N_FLAGS> const flagDefs = {{
+        static lsst::meas::base::FlagDefinitionList flagDefs = {{
             {"flag", "general failure flag, set if anything went wrong"},
             {"flag_noCounts", "Object to be centroided has no counts"},
             {"flag_edge", "Object too close to edge"}
         }};
-        _flagHandler = lsst::meas::base::FlagHandler::addFields(schema, name, flagDefs.begin(),
-                       flagDefs.end());
+        _flagHandler = lsst::meas::base::FlagHandler::addFields(schema, name, flagDefs);
     }
     
     void measure(
@@ -101,7 +93,7 @@ public:
         measRecord.set(_centroidKey, result); // better than NaN
     
         measRecord.set(_centroidKey, result);
-        _flagHandler.setValue(measRecord, FAILURE, false);  // if we had a suspect flag, we'd set that instead
+        _flagHandler.setValue(measRecord, "flag", false);  // if we had a suspect flag, we'd set that instead
     }
 
     void fail(lsst::afw::table::SourceRecord & measRecord, lsst::meas::base::MeasurementError * error) const {

--- a/tests/testApertureFlux.py
+++ b/tests/testApertureFlux.py
@@ -81,8 +81,8 @@ class ApertureFluxTestCase(lsst.utils.tests.TestCase):
                     """
                     result = method(image, ellipse, self.ctrl)
                     self.assertClose(result.flux, area)
-                    self.assertFalse(result.getFlag(ApertureFluxAlgorithm.APERTURE_TRUNCATED))
-                    self.assertFalse(result.getFlag(ApertureFluxAlgorithm.SINC_COEFFS_TRUNCATED))
+                    self.assertFalse(result.getFlag(ApertureFluxAlgorithm.APERTURE_TRUNCATED.number))
+                    self.assertFalse(result.getFlag(ApertureFluxAlgorithm.SINC_COEFFS_TRUNCATED.number))
                     if hasattr(image, "getVariance"):
                         self.assertClose(result.fluxSigma, (area*0.25)**0.5)
                     else:
@@ -97,8 +97,8 @@ class ApertureFluxTestCase(lsst.utils.tests.TestCase):
             lsst.afw.geom.ellipses.Ellipse(lsst.afw.geom.ellipses.Axes(12.0, 12.0),
                                            lsst.afw.geom.Point2D(25.0, -60.0)),
             self.ctrl)
-        self.assertTrue(invalid.getFlag(ApertureFluxAlgorithm.APERTURE_TRUNCATED))
-        self.assertFalse(invalid.getFlag(ApertureFluxAlgorithm.SINC_COEFFS_TRUNCATED))
+        self.assertTrue(invalid.getFlag(ApertureFluxAlgorithm.APERTURE_TRUNCATED.number))
+        self.assertFalse(invalid.getFlag(ApertureFluxAlgorithm.SINC_COEFFS_TRUNCATED.number))
         self.assertTrue(np.isnan(invalid.flux))
 
     def testSinc(self):
@@ -121,8 +121,8 @@ class ApertureFluxTestCase(lsst.utils.tests.TestCase):
                     # test that all the ways we could invoke sinc flux measurement produce the expected result
                     result = method(image, ellipse, self.ctrl)
                     self.assertClose(result.flux, area, rtol=1E-3)
-                    self.assertFalse(result.getFlag(ApertureFluxAlgorithm.APERTURE_TRUNCATED))
-                    self.assertFalse(result.getFlag(ApertureFluxAlgorithm.SINC_COEFFS_TRUNCATED))
+                    self.assertFalse(result.getFlag(ApertureFluxAlgorithm.APERTURE_TRUNCATED.number))
+                    self.assertFalse(result.getFlag(ApertureFluxAlgorithm.SINC_COEFFS_TRUNCATED.number))
                     if hasattr(image, "getVariance"):
                         self.assertFalse(np.isnan(result.fluxSigma))
                     else:
@@ -137,8 +137,8 @@ class ApertureFluxTestCase(lsst.utils.tests.TestCase):
             lsst.afw.geom.ellipses.Ellipse(lsst.afw.geom.ellipses.Axes(9.0, 9.0),
                                            lsst.afw.geom.Point2D(25.0, -60.0)),
             self.ctrl)
-        self.assertTrue(invalid1.getFlag(ApertureFluxAlgorithm.APERTURE_TRUNCATED))
-        self.assertTrue(invalid1.getFlag(ApertureFluxAlgorithm.SINC_COEFFS_TRUNCATED))
+        self.assertTrue(invalid1.getFlag(ApertureFluxAlgorithm.APERTURE_TRUNCATED.number))
+        self.assertTrue(invalid1.getFlag(ApertureFluxAlgorithm.SINC_COEFFS_TRUNCATED.number))
         self.assertTrue(np.isnan(invalid1.flux))
         # test failure conditions when the aperture is not truncated, but the sinc coeffs are
         invalid2 = ApertureFluxAlgorithm.computeSincFlux(
@@ -146,8 +146,8 @@ class ApertureFluxTestCase(lsst.utils.tests.TestCase):
             lsst.afw.geom.ellipses.Ellipse(lsst.afw.geom.ellipses.Axes(9.0, 9.0),
                                            lsst.afw.geom.Point2D(30.0, -60.0)),
             self.ctrl)
-        self.assertFalse(invalid2.getFlag(ApertureFluxAlgorithm.APERTURE_TRUNCATED))
-        self.assertTrue(invalid2.getFlag(ApertureFluxAlgorithm.SINC_COEFFS_TRUNCATED))
+        self.assertFalse(invalid2.getFlag(ApertureFluxAlgorithm.APERTURE_TRUNCATED.number))
+        self.assertTrue(invalid2.getFlag(ApertureFluxAlgorithm.SINC_COEFFS_TRUNCATED.number))
         self.assertFalse(np.isnan(invalid2.flux))
 
 

--- a/tests/testCatalogCalculation.py
+++ b/tests/testCatalogCalculation.py
@@ -25,7 +25,8 @@ class FailCC(catCalc.CatalogCalculationPlugin):
         self.failKey = schema.addField(name + "_fail", type="Flag", doc="Failure test")
 
     def calculate(self, measRecord):
-        raise MeasurementError("Supposed to fail", FlagHandler.FAILURE)
+        #  note: flagbit doesn't matter, since a FlagHandler isn't used
+        raise MeasurementError("Supposed to fail", 0)
 
     def fail(self, measRecord, error=None):
         measRecord.set(self.failKey, True)

--- a/tests/testCentroidChecker.py
+++ b/tests/testCentroidChecker.py
@@ -30,11 +30,10 @@ import lsst.utils.tests
 import lsst.meas.base
 import lsst.meas.base.tests
 from lsst.meas.base.tests import (AlgorithmTestCase)
-from lsst.meas.base.flagDecorator import addFlagHandler
 import lsst.pex.config
 from lsst.meas.base.pluginRegistry import register
 from lsst.meas.base.sfm import SingleFramePluginConfig, SingleFramePlugin
-
+from lsst.meas.base import FlagDefinitionList, FlagDefinition, FlagHandler
 
 class CentroiderConfig(SingleFramePluginConfig):
 
@@ -47,7 +46,6 @@ class CentroiderConfig(SingleFramePluginConfig):
 
 
 @register("test_Centroider")
-@addFlagHandler(("flag", "General Failure error"), ("test_flag", "second flag"))
 class Centroider(SingleFramePlugin):
     '''
     This is a sample Python plugin.  The flag handler for this plugin is created
@@ -65,6 +63,10 @@ class Centroider(SingleFramePlugin):
     def __init__(self, config, name, schema, metadata):
         SingleFramePlugin.__init__(self, config, name, schema, metadata)
 
+        flagDefs = FlagDefinitionList()
+        flagDefs.add("flag", "General Failure error")
+        flagDefs.add("test_flag", "second flag")
+        self.flagHandler = FlagHandler.addFields(schema, name, flagDefs)
         self.xKey = schema.addField(schema.join(name, "x"), type=np.float64)
         self.yKey = schema.addField(schema.join(name, "y"), type=np.float64)
         if self.config.dist is None:

--- a/tests/testPsfFlux.py
+++ b/tests/testPsfFlux.py
@@ -83,7 +83,7 @@ class PsfFluxTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
         maskArray[:, :] |= badMask
         with self.assertRaises(lsst.meas.base.MeasurementError) as context:
             algorithm.measure(record, exposure)
-        self.assertEqual(context.exception.getFlagBit(), lsst.meas.base.PsfFluxAlgorithm.NO_GOOD_PIXELS)
+        self.assertEqual(context.exception.getFlagBit(), lsst.meas.base.PsfFluxAlgorithm.NO_GOOD_PIXELS.number)
 
     def testSubImage(self):
         """Test that we don't get confused by images with nonzero xy0, and that the EDGE flag is set
@@ -169,7 +169,6 @@ class PsfFluxTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
                          rtol=1E-3)
         self.assertLess(measRecord.get("base_PsfFlux_fluxSigma"), 500.0)
 
-
 class PsfFluxTransformTestCase(FluxTransformTestCase, SingleFramePluginTransformSetupHelper,
                                lsst.utils.tests.TestCase):
     controlClass = lsst.meas.base.PsfFluxControl
@@ -178,7 +177,6 @@ class PsfFluxTransformTestCase(FluxTransformTestCase, SingleFramePluginTransform
     flagNames = ('flag', 'flag_noGoodPixels', 'flag_edge')
     singleFramePlugins = ('base_PsfFlux',)
     forcedPlugins = ('base_PsfFlux',)
-
 
 class TestMemory(lsst.utils.tests.MemoryTestCase):
     pass

--- a/tests/testSdssShape.py
+++ b/tests/testSdssShape.py
@@ -74,17 +74,17 @@ class SdssShapeTestCase(lsst.meas.base.tests.AlgorithmTestCase, lsst.utils.tests
         self.assertFinite(result.xx_yy_Cov)
         self.assertFinite(result.xx_xy_Cov)
         self.assertFinite(result.yy_xy_Cov)
-        self.assertFalse(result.getFlag(lsst.meas.base.SdssShapeAlgorithm.FAILURE))
-        self.assertFalse(result.getFlag(lsst.meas.base.SdssShapeAlgorithm.UNWEIGHTED_BAD))
-        self.assertFalse(result.getFlag(lsst.meas.base.SdssShapeAlgorithm.UNWEIGHTED))
-        self.assertFalse(result.getFlag(lsst.meas.base.SdssShapeAlgorithm.SHIFT))
-        self.assertFalse(result.getFlag(lsst.meas.base.SdssShapeAlgorithm.MAXITER))
+        self.assertFalse(result.getFlag(lsst.meas.base.SdssShapeAlgorithm.FAILURE.number))
+        self.assertFalse(result.getFlag(lsst.meas.base.SdssShapeAlgorithm.UNWEIGHTED_BAD.number))
+        self.assertFalse(result.getFlag(lsst.meas.base.SdssShapeAlgorithm.UNWEIGHTED.number))
+        self.assertFalse(result.getFlag(lsst.meas.base.SdssShapeAlgorithm.SHIFT.number))
+        self.assertFalse(result.getFlag(lsst.meas.base.SdssShapeAlgorithm.MAXITER.number))
 
     def _checkPsfShape(self, result, psfResult, psfTruth):
         self.assertClose(psfResult.getIxx(), psfTruth.getIxx(), rtol=1E-4)
         self.assertClose(psfResult.getIyy(), psfTruth.getIyy(), rtol=1E-4)
         self.assertClose(psfResult.getIxy(), psfTruth.getIxy(), rtol=1E-4)
-        self.assertFalse(result.getFlag(lsst.meas.base.SdssShapeAlgorithm.PSF_SHAPE_BAD))
+        self.assertFalse(result.getFlag(lsst.meas.base.SdssShapeAlgorithm.PSF_SHAPE_BAD.number))
 
     def testMeasureGoodPsf(self):
         """Test that we measure shapes and record the PSF shape correctly
@@ -129,13 +129,14 @@ class SdssShapeTestCase(lsst.meas.base.tests.AlgorithmTestCase, lsst.utils.tests
         for record in catalog:
             result = record.get(key)
             self._checkShape(result, record)
-            self.assertTrue(result.getFlag(lsst.meas.base.SdssShapeAlgorithm.PSF_SHAPE_BAD))
+            self.assertTrue(result.getFlag(lsst.meas.base.SdssShapeAlgorithm.PSF_SHAPE_BAD.number))
 
 
 class SdssShapeTransformTestCase(lsst.meas.base.tests.FluxTransformTestCase,
                                  lsst.meas.base.tests.CentroidTransformTestCase,
                                  lsst.meas.base.tests.SingleFramePluginTransformSetupHelper,
                                  lsst.utils.tests.TestCase):
+
     name = "sdssShape"
     controlClass = lsst.meas.base.SdssShapeControl
     algorithmClass = lsst.meas.base.SdssShapeAlgorithm
@@ -152,7 +153,6 @@ class SdssShapeTransformTestCase(lsst.meas.base.tests.FluxTransformTestCase,
             for field in ('xx', 'yy', 'xy', 'xxSigma', 'yySigma', 'xySigma', 'psf_xx', 'psf_yy', 'psf_xy'):
                 if record.schema.join(name, field) in record.schema:
                     record[record.schema.join(name, field)] = np.random.random()
-
     def _compareFieldsInRecords(self, inSrc, outSrc, name):
         lsst.meas.base.tests.FluxTransformTestCase._compareFieldsInRecords(self, inSrc, outSrc, name)
         lsst.meas.base.tests.CentroidTransformTestCase._compareFieldsInRecords(self, inSrc, outSrc, name)
@@ -172,7 +172,6 @@ class SdssShapeTransformTestCase(lsst.meas.base.tests.FluxTransformTestCase,
         np.testing.assert_array_almost_equal(
             np.dot(np.dot(m, inShape.getShapeErr()), m.transpose()), outShape.getShapeErr()
         )
-
         if self.testPsf:
             inPsfShape = lsst.meas.base.ShapeResultKey(
                 inSrc.schema[inSrc.schema.join(name, "psf")]


### PR DESCRIPTION
enum is replaced with static FlagDefinition of the same name
If the index of the flag is required a FlagDefinition.number
If the flag name is required, use FlagDefinition.name

Remove the old style of initializing the FlagHandler using iterator
to a std::array<FlagDefinition>.  A new class FlagDefinitionList
is introduced to specify the FlagDefinitions used to initialize the
FlagHandler.  Add flags to the FlagDefinitionList using the methods
addFailureFlag() and add(name, doc). When done, use the FlagHandler
initializer addFields(schema, name, flagDefinitionList).

An optional exclusion list exclDefs is provided if some members of
the algorithms FlagDefinitionList are not desired for a particular
configuration.  The _flagHandler keeps the same numbering of flags
whether or not a flag is excluded -- the FlagDefinition.number is
fixed.  But the flag is not added to the schema if it is excluded.

It is now optional whether a General Failure flag is defined for the
flagHandler.  If it is not added to the FlagDefinitionList, the
flagHandler will not perform the function of setting the general
flag when the other flags are set in handleFailure.

Remove the FlagHandler::FAILURE which was used to always identify
the failure flag as number 0. Flags may be added in any order.
Use flagHandler.getFailureFlagNumber() to get the correct index.