### PR TITLE
DM-10237: fix errors in blendedness calculation

### DIFF
--- a/include/lsst/meas/base/Blendedness.h
+++ b/include/lsst/meas/base/Blendedness.h
@@ -105,6 +105,23 @@ public:
      */
     static float computeAbsExpectation(float data, float variance);
 
+    /**
+     *  Compute the bias induced by using the absolute value of a pixel instead of its value.
+     *
+     *  The computation assumes the true distribution for the pixel is a Gaussian
+     *  with mean mu and the given variance.  To compute mu from the data, use
+     *  computeAbsExpectation.
+     *
+     *  This computes
+     *  @f[
+     *      \sqrt{\frac{2}{\pi}}\sigma e^{-\frac{\mu^2}{2\sigma^2}}
+     *          - \mu\,\mathrm{erfc}\left(\frac{\mu}{\sqrt{2}\sigma}\right)
+     *  @f]
+     *  where @f$\mu@f$ is the mean of the underlying distribution and @f$\sigma^2@f$
+     *  is its variance.
+     */
+    static float computeAbsBias(float mu, float variance);
+
     void measureChildPixels(
         afw::image::MaskedImage<float> const & image,
         afw::table::SourceRecord & child

--- a/include/lsst/meas/base/Blendedness.h
+++ b/include/lsst/meas/base/Blendedness.h
@@ -87,6 +87,24 @@ public:
 
     BlendednessAlgorithm(Control const & ctrl, std::string const & name, afw::table::Schema & schema);
 
+    /**
+     *  Compute the posterior expectation value of the true flux in a pixel
+     *  from its (Gaussian) likelihood and a flat nonnegative prior.
+     *
+     *  This computes
+     *  @f[
+     *       \frac{\int_0^\infty f \frac{1}{\sqrt{2\pi}\sigma} e^{-\frac{(f-z)^2}{2\sigma^2}} df}
+                  {\int_0^\infty \frac{1}{\sqrt{2\pi}\sigma} e^{-\frac{(f-z)^2}{2\sigma^2}} df}
+     *  @f]
+     *  where @f$z@f$ is the (noisy) pixel value and @f$\sigma^2@f$ is the pixel variance.  This
+     *  approaches @f$z@f$ when @f$z \gg \sigma@f$ and @f$0@f$ when @f$z \ll -\sigma@f$.
+     *
+     *  We use single precision here for performance reasons; this function is called in a loop
+     *  over single-precision pixels, and relies on a number of calls to exp and erfc, which are
+     *  much faster in single precision.
+     */
+    static float computeAbsExpectation(float data, float variance);
+
     void measureChildPixels(
         afw::image::MaskedImage<float> const & image,
         afw::table::SourceRecord & child

--- a/python/lsst/meas/base/blendedness.cc
+++ b/python/lsst/meas/base/blendedness.cc
@@ -67,6 +67,8 @@ PyBlendenessAlgorithm declareBlendednessAlgorithm(py::module &mod) {
 
     cls.def_static("computeAbsExpectation", &BlendednessAlgorithm::computeAbsExpectation,
                    "data"_a, "variance"_a);
+    cls.def_static("computeAbsBias", &BlendednessAlgorithm::computeAbsBias,
+                   "mu"_a, "variance"_a);
     cls.def("measureChildPixels", &BlendednessAlgorithm::measureChildPixels, "image"_a, "child"_a);
     cls.def("measureParentPixels", &BlendednessAlgorithm::measureParentPixels, "image"_a, "child"_a);
     cls.def("measure", &BlendednessAlgorithm::measure, "measRecord"_a, "exposure"_a);

--- a/python/lsst/meas/base/blendedness.cc
+++ b/python/lsst/meas/base/blendedness.cc
@@ -65,6 +65,8 @@ PyBlendenessAlgorithm declareBlendednessAlgorithm(py::module &mod) {
     cls.attr("NO_CENTROID") = py::cast(BlendednessAlgorithm::NO_CENTROID);
     cls.attr("NO_SHAPE") = py::cast(BlendednessAlgorithm::NO_SHAPE);
 
+    cls.def_static("computeAbsExpectation", &BlendednessAlgorithm::computeAbsExpectation,
+                   "data"_a, "variance"_a);
     cls.def("measureChildPixels", &BlendednessAlgorithm::measureChildPixels, "image"_a, "child"_a);
     cls.def("measureParentPixels", &BlendednessAlgorithm::measureParentPixels, "image"_a, "child"_a);
     cls.def("measure", &BlendednessAlgorithm::measure, "measRecord"_a, "exposure"_a);

--- a/src/Blendedness.cc
+++ b/src/Blendedness.cc
@@ -210,7 +210,7 @@ void computeMoments(
             float variance = pixelIter.variance();
             float mu = BlendednessAlgorithm::computeAbsExpectation(data, variance);
             float bias = BlendednessAlgorithm::computeAbsBias(mu, variance);
-            accumulatorAbs(d.getX(), d.getY(), weight, std::max(std::abs(data) - bias, 0.0f));
+            accumulatorAbs(d.getX(), d.getY(), weight, std::abs(data) - bias);
         }
     }
 }
@@ -360,7 +360,7 @@ void BlendednessAlgorithm::_measureMoments(
             );
         if (_ctrl.doFlux) {
             child.set(fluxRawKey, accumulatorRaw.getFlux());
-            child.set(fluxAbsKey, accumulatorAbs.getFlux());
+            child.set(fluxAbsKey, std::max(accumulatorAbs.getFlux(), 0.0));
         }
         _shapeRawKey.set(child, accumulatorRaw.getShape());
         _shapeAbsKey.set(child, accumulatorAbs.getShape());
@@ -376,7 +376,7 @@ void BlendednessAlgorithm::_measureMoments(
             accumulatorAbs
         );
         child.set(fluxRawKey, accumulatorRaw.getFlux());
-        child.set(fluxAbsKey, accumulatorAbs.getFlux());
+        child.set(fluxAbsKey, std::max(accumulatorAbs.getFlux(), 0.0));
     }
 }
 

--- a/src/Blendedness.cc
+++ b/src/Blendedness.cc
@@ -209,9 +209,7 @@ void computeMoments(
             accumulatorRaw(d.getX(), d.getY(), weight, data);
             float variance = pixelIter.variance();
             float mu = BlendednessAlgorithm::computeAbsExpectation(data, variance);
-            float bias = (std::sqrt(2.0f*variance/boost::math::constants::pi<float>())*
-                          std::exp(-0.5f*(mu*mu)/variance)) -
-                mu*boost::math::erfc(mu/std::sqrt(2.0f*variance));
+            float bias = BlendednessAlgorithm::computeAbsBias(mu, variance);
             accumulatorAbs(d.getX(), d.getY(), weight, std::max(std::abs(data) - bias, 0.0f));
         }
     }
@@ -290,6 +288,11 @@ float BlendednessAlgorithm::computeAbsExpectation(float data, float variance) {
     return data + (std::sqrt(0.5f*variance/boost::math::constants::pi<float>()) *
                    std::exp(-0.5f*(data*data)/variance) / normalization);
 }
+
+float BlendednessAlgorithm::computeAbsBias(float mu, float variance) {
+    return (std::sqrt(2.0f*variance/boost::math::constants::pi<float>()) *
+                      std::exp(-0.5f*(mu*mu)/variance)) -
+            mu*boost::math::erfc(mu/std::sqrt(2.0f*variance));
 }
 
 void BlendednessAlgorithm::_measureMoments(

--- a/src/Blendedness.cc
+++ b/src/Blendedness.cc
@@ -23,8 +23,7 @@
 
 #include <cmath>
 
-#include "boost/math/special_functions/erf.hpp"
-#include <boost/math/constants/constants.hpp>
+#include "boost/math/constants/constants.hpp"
 
 #include "lsst/meas/base/Blendedness.h"
 #include "lsst/afw/detection/HeavyFootprint.h"
@@ -280,7 +279,7 @@ BlendednessAlgorithm::BlendednessAlgorithm(Control const & ctrl,  std::string co
 }
 
 float BlendednessAlgorithm::computeAbsExpectation(float data, float variance) {
-    float normalization = 0.5f*boost::math::erfc(-data/std::sqrt(2.0f*variance));
+    float normalization = 0.5f*std::erfc(-data/std::sqrt(2.0f*variance));
     if (!(normalization > 0)) {
         // avoid division by zero; we know the limit at data << -sigma -> 0.
         return 0.0;
@@ -292,7 +291,7 @@ float BlendednessAlgorithm::computeAbsExpectation(float data, float variance) {
 float BlendednessAlgorithm::computeAbsBias(float mu, float variance) {
     return (std::sqrt(2.0f*variance/boost::math::constants::pi<float>()) *
                       std::exp(-0.5f*(mu*mu)/variance)) -
-            mu*boost::math::erfc(mu/std::sqrt(2.0f*variance));
+            mu*std::erfc(mu/std::sqrt(2.0f*variance));
 }
 
 void BlendednessAlgorithm::_measureMoments(

--- a/tests/testBlendedness.py
+++ b/tests/testBlendedness.py
@@ -64,6 +64,16 @@ class BlendednessTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
         del self.bbox
         del self.dataset
 
+    def testAbsExpectation(self):
+        f = lsst.meas.base.BlendednessAlgorithm.computeAbsExpectation
+        # comparison values computed with Mathematica
+        self.assertFloatsAlmostEqual(f(-1.0, 1.5**2), 0.897767011, rtol=1E-5)
+        self.assertFloatsAlmostEqual(f(0.0, 1.5**2), 1.19682684, rtol=1E-5)
+        self.assertFloatsAlmostEqual(f(1.0, 1.5**2), 1.64102639, rtol=1E-5)
+        self.assertFloatsAlmostEqual(f(-1.0, 0.3**2), 0.0783651228, rtol=1E-5)
+        self.assertFloatsAlmostEqual(f(0.0, 0.3**2), 0.239365368, rtol=1E-5)
+        self.assertFloatsAlmostEqual(f(1.0, 0.3**2), 1.00046288, rtol=1E-5)
+
     def testBlendedness(self):
         """
         Check that we measure a positive blendedness for two overlapping sources

--- a/tests/testBlendedness.py
+++ b/tests/testBlendedness.py
@@ -74,6 +74,16 @@ class BlendednessTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
         self.assertFloatsAlmostEqual(f(0.0, 0.3**2), 0.239365368, rtol=1E-5)
         self.assertFloatsAlmostEqual(f(1.0, 0.3**2), 1.00046288, rtol=1E-5)
 
+    def testAbsBias(self):
+        f = lsst.meas.base.BlendednessAlgorithm.computeAbsBias
+        # comparison values computed with Mathematica
+        self.assertFloatsAlmostEqual(f(0.0, 1.5**2), 1.19682684, rtol=1E-5)
+        self.assertFloatsAlmostEqual(f(0.5, 1.5**2), 0.762708343, rtol=1E-5)
+        self.assertFloatsAlmostEqual(f(1.0, 1.5**2), 0.453358941, rtol=1E-5)
+        self.assertFloatsAlmostEqual(f(0.0, 0.3**2), 0.239365368, rtol=1E-5)
+        self.assertFloatsAlmostEqual(f(0.5, 0.3**2), 0.011895931, rtol=1E-5)
+        self.assertFloatsAlmostEqual(f(1.0, 0.3**2), 0.0000672467314, rtol=1E-5)
+
     def testBlendedness(self):
         """
         Check that we measure a positive blendedness for two overlapping sources


### PR DESCRIPTION
This addresses three problems in the blendedness calculation:
 - a simple transcription bug in what is now computeAbsExpectation (this is what originally spawened the ticket);
 - the integral in what is now computeAbsExpectation was over a nonnormalized probability;
 - we were truncating de-biased absolute values before summing them, which was introducing another bias we weren't correcting for.

I've also added some new unit tests.