### PR TITLE
tickets/DM-10359

### DIFF
--- a/doc/ReconstructingMeasurements.rst
+++ b/doc/ReconstructingMeasurements.rst
@@ -1,0 +1,86 @@
+###############################
+Investigating LSST Measurements
+###############################
+
+Before the LSST software stack can make measurements on a source identified
+within an image, it must first mask out any surrounding sources so that they
+do not contaminate the measurements. The software accomplishes this by
+replacing every other source in an image with noise that corresponds to the
+measured background distribution.
+
+When attempting to understand the output of measurements after the analysis is
+complete, it is often useful to put an exposure back into the same state it was
+in when the measurement was made. What this means in practice is that the noise
+used to mask out adjacent sources will need to be reconstructed in the same
+manner (using the same seed) as in the original measurement. This returns the
+image to a bitwise identical state, so any measurements will produce the exact
+same output. The example below demonstrates how to do this using a fully
+processed ci-hsc dataset.
+
+.. code-block:: python
+
+    from lsst.meas.base.measurementInvestigationLib import rebuildNoiseReplacer
+    from lsst.daf.persistence import Butler
+
+    ciHscDataPath = "" # Set this to the path to a ci-hsc data repository.
+    ciHscDataPath = "/ssd/nlust/repos_lsst/ci_hsc/DATA/rerun/ci_hsc/"
+
+    # Create a butler object for loading in the data.
+    butler = Butler(ciHscDataPath)
+
+    # Create a data Id for a single ccd.
+    dataId = {"visit":903334, "ccd":16, "filter":"HSC-R"}
+
+    # Load in the calibrated exposure, and the associated source catalog.
+    exposure = butler.get("calexp", dataId)
+    srcCat = butler.get("src", dataId)
+
+    # Reconstruct a noise replacer from the loaded data.
+    noiseReplacer = rebuildNoiseReplacer(exposure, srcCat)
+
+The  NoiseReplacer object, when created, records the pixel values for all
+sources in the exposure internally and then sets the pixel values in the
+exposure to random noise drawn from the background distribution. This allows
+individual sources to be visualized by adding them source back in into the
+exposure with a call to the NoiseReplacer's ``insertSource`` method. The source
+can be  removed again with a call to the ``removeSource`` method. When all
+operations involving the NoiseReplacer are completed, calling ``end`` will
+reset the exposure back to its original state.
+
+Rather than inserting and viewing individual sources, a NoiseReplacer object
+is more commonly used in the context of making measurements. The
+following example shows how to rerun measurements, using a reconstructed
+NoiseReplacer. The example selects a subset of objects for which measurements
+are to be rerun, and places the outputs into a new catalog, retaining the same
+id for each object.
+
+.. code-block:: python
+
+    # Continued from the above example
+    from lsst.afw.table import SourceTable
+    from lsst.meas.base.measurementInvestigationLib import makeRerunCatalog
+    from lsst.meas.base import (SingleFrameMeasurementConfig,
+                                SingleFrameMeasurementTask)
+
+    # Make a list of ids of objects to remeasure
+    idsToRerun = [775958066192449538, 775958066192449539,
+                  775958066192449540, 775958066192449541]
+
+    # Fields to copy from old catalog, these are generally fields added outside
+    # the measurement framework, that may be desirable to maintain
+    fields = ["deblend_nChild"]
+
+    # Create a new schema object, and use it to initialize a measurement task
+    schema = SourceTable.makeMinimalSchema()
+
+    # Configure any plugins at this stage.
+    measConfig = SingleFrameMeasurementConfig()
+
+    measTask = SingleFrameMeasurementTask(schema, config=measConfig)
+
+    # Create a Measurement catalog containing only the ids to remeasure
+    newSrcCatalog = makeRerunCatalog(schema, srcCat, idsToRerun, fields=fields)
+
+    # Re-run measure on the sources selected above, using the reconstructed
+    # noise replacer.
+    measTask.runPlugins(noiseReplacer, newSrcCatalog, exposure)

--- a/python/lsst/meas/base/measurementInvestigationLib.py
+++ b/python/lsst/meas/base/measurementInvestigationLib.py
@@ -1,0 +1,126 @@
+#
+# LSST Data Management System
+#
+# Copyright 2008-2017  AURA/LSST.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+
+from collections import Iterable
+
+from lsst.afw.table import SourceCatalog
+from lsst.meas.base import NoiseReplacer, NoiseReplacerConfig
+from lsst.meas.base import SingleFrameMeasurementTask as SFMT
+
+
+def rebuildNoiseReplacer(exposure, measCat):
+    """ Recreate NoiseReplacer used in measurement
+
+    Given a measurement catalog and the exposure on which the measurements were
+    made, reconstruct the NoiseReplacer object that was used to mask out
+    sources during measurement.
+
+    Parameters
+    ----------
+    exposure : lsst.awf.exposure.Exposure
+        The exposure on which measurements were made
+
+    meaCat : lsst.afw.table.SourceCatalog
+        Catalog containing the outputs of measurements on each source
+
+    Returns
+    -------
+    noiseReplacer : lsst.meas.base.NoiseReplacer
+        Object used to replace and or restore sources in the exposure with
+        deterministic noise
+    """
+
+    algMetadata = measCat.getMetadata()
+    noiseReplacerConf = NoiseReplacerConfig()
+    noiseReplacerConf.noiseSeedMultiplier = \
+        algMetadata.get(SFMT.NOISE_SEED_MULTIPLIER)
+    noiseReplacerConf.noiseSource = algMetadata.get(SFMT.NOISE_SOURCE)
+    noiseReplacerConf.noiseOffset = algMetadata.get(SFMT.NOISE_OFFSET)
+
+    footprints = {src.getId(): (src.getParent(), src.getFootprint())
+                  for src in measCat}
+
+    try:
+        exposureId = algMetadata.get(SFMT.NOISE_EXPOSURE_ID)
+    except Exception:
+        exposureId = None
+
+    noiseReplacer = NoiseReplacer(noiseReplacerConf, exposure, footprints,
+                                  exposureId=exposureId)
+    return noiseReplacer
+
+
+def makeRerunCatalog(schema, oldCatalog, idList, fields=None):
+    """ Creates a catalog prepopulated with ids
+
+    This function is used to generate a SourceCatalog containing blank records
+    with Ids specified in the idList parameter
+
+    This function is primarily used when rerunning measurements on a footprint.
+    Specifying ids in a new measurement catalog which correspond to ids in an
+    old catalog makes comparing results much easier.
+
+    Parameters
+    ----------
+    schema : lsst.afw.table.Schema
+        Schema used to describe the fields in the resulting SourceCatalog
+
+    oldCatalog : lsst.afw.table.SourceCatalog
+        Catalog containing previous measurements.
+
+    idList : iterable
+        Python iterable whose values should be numbers corresponding to
+        measurement ids, ids must exist in the oldCatalog
+
+    fields : iterable
+        Python iterable whose entries should be strings corresponding to schema
+        keys that exist in both the old catalog and input schema. Fields listed
+        will be copied from the old catalog into the new catalog.
+
+    Returns
+    -------
+    measCat : lsst.afw.table.SourceCatalog
+        SourceCatalog prepopulated with entries corresponding to the ids
+        specified
+    """
+
+    if fields is None:
+        fields = []
+    if not isinstance(fields, Iterable):
+        raise RuntimeError("fields list must be an iterable with string"
+                           "elements")
+    for entry in fields:
+        if entry not in schema:
+            schema.addField(oldCatalog.schema.find(entry).field)
+
+    measCat = SourceCatalog(schema)
+    for srcId in idList:
+        oldSrc = oldCatalog.find(srcId)
+        src = measCat.addNew()
+        src.setId(srcId)
+        src.setFootprint(oldSrc.getFootprint())
+        src.setParent(oldSrc.getParent())
+        src.setCoord(oldSrc.getCoord())
+        for entry in fields:
+            src[entry] = oldSrc[entry]
+    return measCat


### PR DESCRIPTION
Many of the tools nessisary for reconstructing the state of an
exposure at the time of a measurement, and possibly re-running
the measurement already exist, but are not easy or convienent.
This commit aims to increase the ease of accomplishing these
tasks by introducing convienence functionality, and adding a
document which contains runable examples.