### PR TITLE
DM-11539: Fix test for pytest and make flake8 clean

### DIFF
--- a/examples/runSingleFrameTask.py
+++ b/examples/runSingleFrameTask.py
@@ -111,7 +111,6 @@ def run(display=False):
                 ds9.dot('o', *xy, size=config.plugins["base_CircularApertureFlux"].radii[0],
                         ctype=ds9.YELLOW, frame=frame)
 
-#-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 if __name__ == "__main__":
     import argparse
@@ -124,7 +123,7 @@ if __name__ == "__main__":
 
     if args.debug:
         try:
-            import debug
+            import debug  # noqa F401
         except ImportError as e:
             print(e, file=sys.stderr)
 

--- a/python/lsst/meas/base/applyApCorr.py
+++ b/python/lsst/meas/base/applyApCorr.py
@@ -176,7 +176,6 @@ class ApplyApCorrTask(lsst.pipe.base.Task):
                 continue
             self.apCorrInfoDict[name] = ApCorrInfo(schema=schema, model=model, name=name)
 
-
     def run(self, catalog, apCorrMap):
         """Apply aperture corrections to a catalog of sources
 

--- a/python/lsst/meas/base/baseMeasurement.py
+++ b/python/lsst/meas/base/baseMeasurement.py
@@ -22,7 +22,6 @@
 #
 """Base measurement task, which subclassed by the single frame and forced measurement tasks.
 """
-from lsst.log import Log
 import lsst.pipe.base
 import lsst.pex.config
 
@@ -234,7 +233,7 @@ class BaseMeasurementTask(lsst.pipe.base.Task):
             #   The task will use this name to log plugin errors, regardless.
             if hasattr(PluginClass, "hasLogName") and PluginClass.hasLogName:
                 self.plugins[name] = PluginClass(config, name, metadata=self.algMetadata,
-                   logName=self.getPluginLogName(name), **kwds)
+                                                 logName=self.getPluginLogName(name), **kwds)
             else:
                 self.plugins[name] = PluginClass(config, name, metadata=self.algMetadata, **kwds)
 
@@ -300,13 +299,13 @@ class BaseMeasurementTask(lsst.pipe.base.Task):
             raise
         except MeasurementError as error:
             lsst.log.Log.getLogger(self.getPluginLogName(plugin.name)).debug(
-                          "MeasurementError in %s.measure on record %s: %s"
-                          % (plugin.name, measRecord.getId(), error))
+                "MeasurementError in %s.measure on record %s: %s"
+                % (plugin.name, measRecord.getId(), error))
             plugin.fail(measRecord, error)
         except Exception as error:
             lsst.log.Log.getLogger(self.getPluginLogName(plugin.name)).debug(
-                          "Exception in %s.measure on record %s: %s"
-                          % (plugin.name, measRecord.getId(), error))
+                "Exception in %s.measure on record %s: %s"
+                % (plugin.name, measRecord.getId(), error))
             plugin.fail(measRecord)
 
     def callMeasureN(self, measCat, *args, **kwds):
@@ -368,12 +367,12 @@ class BaseMeasurementTask(lsst.pipe.base.Task):
         except MeasurementError as error:
             for measRecord in measCat:
                 lsst.log.Log.getLogger(self.getPluginLogName(plugin.name)).debug(
-                          "MeasurementError in %s.measureN on records %s-%s: %s"
-                          % (plugin.name, measCat[0].getId(), measCat[-1].getId(), error))
+                    "MeasurementError in %s.measureN on records %s-%s: %s"
+                    % (plugin.name, measCat[0].getId(), measCat[-1].getId(), error))
                 plugin.fail(measRecord, error)
         except Exception as error:
             for measRecord in measCat:
                 plugin.fail(measRecord)
                 lsst.log.Log.getLogger(self.getPluginLogName(plugin.name)).debug(
-                          "Exception in %s.measureN on records %s-%s: %s"
-                          % (plugin.name, measCat[0].getId(), measCat[-1].getId(), error))
+                    "Exception in %s.measureN on records %s-%s: %s"
+                    % (plugin.name, measCat[0].getId(), measCat[-1].getId(), error))

--- a/python/lsst/meas/base/footprintArea.py
+++ b/python/lsst/meas/base/footprintArea.py
@@ -65,4 +65,3 @@ class CatalogCalculationFootprintAreaPlugin(CatalogCalculationPlugin):
         # Should be impossible for this algorithm to fail unless there is no
         # Footprint (and that's a precondition for measurement).
         pass
-

--- a/python/lsst/meas/base/forcedPhotCoadd.py
+++ b/python/lsst/meas/base/forcedPhotCoadd.py
@@ -1,4 +1,3 @@
-from builtins import zip
 #!/usr/bin/env python
 #
 # LSST Data Management System
@@ -21,6 +20,8 @@ from builtins import zip
 # the GNU General Public License along with this program.  If not,
 # see <https://www.lsstcorp.org/LegalNotices/>.
 #
+from builtins import zip
+
 import lsst.pex.config
 import lsst.pipe.base
 import lsst.coadd.utils

--- a/python/lsst/meas/base/noiseReplacer.py
+++ b/python/lsst/meas/base/noiseReplacer.py
@@ -1,5 +1,3 @@
-from builtins import str
-from builtins import object
 #!/usr/bin/env python
 #
 # LSST Data Management System
@@ -22,6 +20,9 @@ from builtins import object
 # the GNU General Public License along with this program.  If not,
 # see <https://www.lsstcorp.org/LegalNotices/>.
 #
+from builtins import str
+from builtins import object
+
 import math
 
 import lsst.afw.detection as afwDet

--- a/python/lsst/meas/base/plugins.py
+++ b/python/lsst/meas/base/plugins.py
@@ -45,10 +45,12 @@ from .gaussianCentroid import GaussianCentroidAlgorithm, GaussianCentroidControl
 from .gaussianFlux import GaussianFluxAlgorithm, GaussianFluxControl, GaussianFluxTransform
 from .exceptions import MeasurementError
 from .naiveCentroid import NaiveCentroidAlgorithm, NaiveCentroidControl, NaiveCentroidTransform
-from .peakLikelihoodFlux import PeakLikelihoodFluxAlgorithm, PeakLikelihoodFluxControl, PeakLikelihoodFluxTransform
+from .peakLikelihoodFlux import PeakLikelihoodFluxAlgorithm, PeakLikelihoodFluxControl, \
+    PeakLikelihoodFluxTransform
 from .pixelFlags import PixelFlagsAlgorithm, PixelFlagsControl
 from .psfFlux import PsfFluxAlgorithm, PsfFluxControl, PsfFluxTransform
-from .scaledApertureFlux import ScaledApertureFluxAlgorithm, ScaledApertureFluxControl, ScaledApertureFluxTransform
+from .scaledApertureFlux import ScaledApertureFluxAlgorithm, ScaledApertureFluxControl, \
+    ScaledApertureFluxTransform
 from .sdssCentroid import SdssCentroidAlgorithm, SdssCentroidControl, SdssCentroidTransform
 from .sdssShape import SdssShapeAlgorithm, SdssShapeControl, SdssShapeTransform
 
@@ -238,7 +240,7 @@ class SingleFrameVariancePlugin(SingleFramePlugin):
             measRecord.set(self.varValue, medVar)
         else:
             raise MeasurementError("Footprint empty, or all pixels are masked, can't compute median",
-                                      self.FAILURE_EMPTY_FOOTPRINT)
+                                   self.FAILURE_EMPTY_FOOTPRINT)
 
     def fail(self, measRecord, error=None):
         # Check that we have a error object and that it is of type MeasurementError

--- a/python/lsst/meas/base/sfm.py
+++ b/python/lsst/meas/base/sfm.py
@@ -29,9 +29,7 @@ slot-eligible fields must be), but non-slot fields may be recorded in other coor
 to avoid information loss (this should, of course, be indicated in the field documentation).
 """
 
-from lsst.pex.config import Field, ListField
-
-from .pluginRegistry import PluginRegistry, PluginMap
+from .pluginRegistry import PluginRegistry
 from .baseMeasurement import (BaseMeasurementPluginConfig, BaseMeasurementPlugin,
                               BaseMeasurementConfig, BaseMeasurementTask)
 from .noiseReplacer import NoiseReplacer, DummyNoiseReplacer

--- a/python/lsst/meas/base/wrappers.py
+++ b/python/lsst/meas/base/wrappers.py
@@ -11,7 +11,7 @@ class WrappedSingleFramePlugin(SingleFramePlugin):
 
     def __init__(self, config, name, schema, metadata, logName=None):
         SingleFramePlugin.__init__(self, config, name, schema, metadata, logName=logName)
-        if hasattr(self, "hasLogName") and self.hasLogName and not logName is None:
+        if hasattr(self, "hasLogName") and self.hasLogName and logName is not None:
             self.cpp = self.factory(config, name, schema, metadata, logName=logName)
         else:
             self.cpp = self.factory(config, name, schema, metadata)
@@ -30,7 +30,7 @@ class WrappedForcedPlugin(ForcedPlugin):
 
     def __init__(self, config, name, schemaMapper, metadata, logName=None):
         ForcedPlugin.__init__(self, config, name, schemaMapper, metadata, logName=logName)
-        if hasattr(self, "hasLogName") and self.hasLogName and not logName is None:
+        if hasattr(self, "hasLogName") and self.hasLogName and logName is not None:
             self.cpp = self.factory(config, name, schemaMapper, metadata, logName=logName)
         else:
             self.cpp = self.factory(config, name, schemaMapper, metadata)
@@ -323,9 +323,11 @@ def wrapForcedAlgorithm(AlgClass, executionOrder, name=None, needsMetadata=False
     and the logName comes last of the three
     """
     if needsSchemaOnly:
-        extractSchemaArg = lambda m: m.editOutputSchema()
+        def extractSchemaArg(m):
+            return m.editOutputSchema()
     else:
-        extractSchemaArg = lambda m: m
+        def extractSchemaArg(m):
+            return m
     if hasMeasureN:
         if needsMetadata:
             def factory(config, name, schemaMapper, metadata, **kwargs):
@@ -416,7 +418,8 @@ def wrapSimpleAlgorithm(AlgClass, executionOrder, name=None, needsMetadata=False
     return (wrapSingleFrameAlgorithm(AlgClass, executionOrder=executionOrder, name=name,
                                      needsMetadata=needsMetadata, hasLogName=hasLogName, **kwds),
             wrapForcedAlgorithm(AlgClass, executionOrder=executionOrder, name=name,
-                                needsMetadata=needsMetadata, hasLogName=hasLogName, needsSchemaOnly=True, **kwds))
+                                needsMetadata=needsMetadata, hasLogName=hasLogName,
+                                needsSchemaOnly=True, **kwds))
 
 
 def wrapTransform(transformClass, hasLogName=False):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,16 @@
+[flake8]
+max-line-length = 110
+ignore = E133, E226, E228, N802, N803, W503
+exclude = __init__.py, tests/testLib.py
+
+[tool:pytest]
+addopts = --flake8
+flake8-ignore = E133 E226 E228 N802 N803 W503
+    # These will not be needed when we use numpydoc
+    baseMeasurement.py E266
+    forcedMeasurement.py E266
+    forcedPhotCcd.py E266
+    forcedPhotCoadd.py E266
+    forcedPhotImage.py E266
+    noiseReplacer.py E266
+    sfm.py E266

--- a/tests/test_ApCorrNameSet.py
+++ b/tests/test_ApCorrNameSet.py
@@ -27,6 +27,19 @@ import lsst.utils.tests
 import lsst.meas.base
 
 
+class MinimalistTestPlugin(lsst.meas.base.SingleFramePlugin):
+    """This class is used below to test registration. It is set up as the
+    minimal class that still has a valid implementation. Whilst these
+    methods are not needed in this test file, the class registered here
+    might appear in other tests that scan the registry."""
+    @classmethod
+    def getExecutionOrder(cls):
+        return cls.CENTROID_ORDER
+
+    def fail(self, measRecord, error=None):
+        pass
+
+
 class ApCorrNameTestCase(lsst.utils.tests.TestCase):
 
     def testDefaultNames(self):
@@ -60,11 +73,11 @@ class ApCorrNameTestCase(lsst.utils.tests.TestCase):
     def testRegisterDecorator(self):
         """Test the shouldApCorr argument of the register decorator for measurement plugins."""
         @lsst.meas.base.register("test_ApCorrPlugin", shouldApCorr=True)
-        class ApCorrPlugin(lsst.meas.base.SingleFramePlugin):
+        class ApCorrPlugin(MinimalistTestPlugin):
             pass
 
         @lsst.meas.base.register("test_NonApCorrPlugin")
-        class NonApCorrPlugin(lsst.meas.base.SingleFramePlugin):
+        class NonApCorrPlugin(MinimalistTestPlugin):
             pass
 
         apCorrSet = lsst.meas.base.getApCorrNameSet()

--- a/tests/test_ApertureFlux.py
+++ b/tests/test_ApertureFlux.py
@@ -70,7 +70,7 @@ class ApertureFluxTestCase(lsst.utils.tests.TestCase):
                                                          position)
                 area = self.computeNaiveArea(position, radius)
                 # test that this isn't the same as the sinc flux
-                self.assertNotClose(
+                self.assertFloatsNotEqual(
                     ApertureFluxAlgorithm.computeSincFlux(self.exposure.getMaskedImage().getImage(),
                                                           ellipse, self.ctrl).flux, area)
 
@@ -112,7 +112,7 @@ class ApertureFluxTestCase(lsst.utils.tests.TestCase):
                                                          position)
                 area = ellipse.getCore().getArea()
                 # test that this isn't the same as the naive flux
-                self.assertNotClose(
+                self.assertFloatsNotEqual(
                     ApertureFluxAlgorithm.computeNaiveFlux(self.exposure.getMaskedImage().getImage(),
                                                            ellipse, self.ctrl).flux, area)
 

--- a/tests/test_PluginLogs.py
+++ b/tests/test_PluginLogs.py
@@ -22,8 +22,6 @@
 #
 
 from __future__ import absolute_import, division, print_function
-from builtins import object
-from contextlib import contextmanager
 import unittest
 import os
 import numpy
@@ -31,19 +29,19 @@ import lsst.afw.table
 import lsst.daf.base
 import lsst.meas.base
 import lsst.utils.tests
-from lsst.meas.base import (SingleFrameMeasurementTask, SingleFrameMeasurementConfig)
 from lsst.meas.base.tests import (AlgorithmTestCase, )
-from lsst.meas.base.apCorrRegistry import addApCorrName
 from lsst.meas.base.sfm import SingleFramePluginConfig, SingleFramePlugin
 from lsst.meas.base.forcedMeasurement import ForcedPlugin
 from lsst.meas.base.pluginRegistry import register
 from lsst.meas.base import FlagDefinitionList, FlagHandler, MeasurementError
+
 
 class LoggingPluginConfig(SingleFramePluginConfig):
     """
     Configuration for Sample Plugin with a FlagHandler.
     """
     pass
+
 
 @register("test_LoggingPlugin")
 class LoggingPlugin(SingleFramePlugin):
@@ -98,10 +96,11 @@ class LoggingPlugin(SingleFramePlugin):
         else:
             self.flagHandler.handleFailure(measRecord, error.cpp)
 
-#   Direct the log given to a file, or to the console if no file is specified
+
 def directLog(log, file=None):
+    """Direct the log given to a file, or to the console if no file is specified"""
     props = "log4j.rootLogger=INFO, FA\n"
-    if file == None:
+    if file is None:
         props += "log4j.appender.FA=ConsoleAppender\n"
     else:
         props += "log4j.appender.FA=FileAppender\n"
@@ -112,6 +111,7 @@ def directLog(log, file=None):
     props += "log4j.appender.FA.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} %p %c %m %X%n\n"
     props += "log4j.logger.main.a=DEBUG\n"
     log.configure_prop(props)
+
 
 class RegisteredPluginsTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
     """
@@ -124,7 +124,7 @@ class RegisteredPluginsTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
     def testSingleFramePlugins(self):
         center = lsst.afw.geom.Point2D(50, 50)
         bbox = lsst.afw.geom.Box2I(lsst.afw.geom.Point2I(0, 0),
-                                        lsst.afw.geom.Extent2I(100,100))
+                                   lsst.afw.geom.Extent2I(100, 100))
         dataset = lsst.meas.base.tests.TestDataset(bbox)
         dataset.addSource(1000000.0, center)
         registry = SingleFramePlugin.registry
@@ -147,7 +147,7 @@ class RegisteredPluginsTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
         #   Test all the ForcedPlugins registered to see if their logName is set as expected.
         center = lsst.afw.geom.Point2D(50, 50)
         bbox = lsst.afw.geom.Box2I(lsst.afw.geom.Point2I(0, 0),
-                                        lsst.afw.geom.Extent2I(100,100))
+                                   lsst.afw.geom.Extent2I(100, 100))
         dataset = lsst.meas.base.tests.TestDataset(bbox)
         dataset.addSource(1000000.0, center)
         registry = ForcedPlugin.registry
@@ -208,7 +208,6 @@ class LoggingPythonTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
         pluginLogName = os.path.join(lsst.utils.getPackageDir('meas_base'), 'tests', 'plugin.log')
         directLog(log, pluginLogName)
         exposure, cat = self.dataset.realize(noise=0.0, schema=schema)
-        source = cat[0]
         task.run(cat, exposure)
         directLog(log, None)
         # direct back to console, closing log files
@@ -235,7 +234,6 @@ class LoggingPythonTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
         pluginLogName = os.path.join(lsst.utils.getPackageDir('meas_base'), 'tests', 'plugin.log')
         directLog(log, pluginLogName)
         exposure, cat = self.dataset.realize(noise=0.0, schema=schema)
-        source = cat[0]
         exposure.setPsf(None)
         # This call throws an error, so be prepared for it
         try:
@@ -251,13 +249,14 @@ class LoggingPythonTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
         #  test that the sample plugin has correctly logged to where we expected it to.
         self.assertTrue(lines.find("ERROR") >= 0)
 
+
 class SingleFrameTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
 
     def setUp(self):
         #   object in corner to trigger EDGE error
         self.center = lsst.afw.geom.Point2D(5, 5)
         self.bbox = lsst.afw.geom.Box2I(lsst.afw.geom.Point2I(0, 0),
-                                        lsst.afw.geom.Extent2I(100,100))
+                                        lsst.afw.geom.Extent2I(100, 100))
         self.dataset = lsst.meas.base.tests.TestDataset(self.bbox)
         self.dataset.addSource(1000000.0, self.center)
         self.task = self.makeSingleFrameMeasurementTask("base_SdssCentroid")
@@ -311,13 +310,14 @@ class SingleFrameTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
         os.unlink(pluginLogName)
         self.assertTrue(lines.find("MeasurementError") < 0)
 
+
 class ForcedTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
 
     def setUp(self):
         #   object in corner to trigger EDGE error
         self.center = lsst.afw.geom.Point2D(0, 0)
         self.bbox = lsst.afw.geom.Box2I(lsst.afw.geom.Point2I(0, 0),
-                                        lsst.afw.geom.Extent2I(100,100))
+                                        lsst.afw.geom.Extent2I(100, 100))
         self.dataset = lsst.meas.base.tests.TestDataset(self.bbox)
         self.dataset.addSource(1000000.0, self.center)
         self.task = self.makeForcedMeasurementTask("base_SdssCentroid")
@@ -378,6 +378,7 @@ class ForcedTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
         fin.close()
         os.unlink(pluginLogName)
         self.assertTrue(lines.find("MeasurementError") < 0)
+
 
 class TestMemory(lsst.utils.tests.MemoryTestCase):
     pass

--- a/tests/test_centroid.py
+++ b/tests/test_centroid.py
@@ -240,14 +240,15 @@ class MonetTestCase(unittest.TestCase):
 
     def readTruth(self, filename):
         """Read Dave Monet's truth table"""
-        for line in open(filename).readlines():
-            if re.search(r"^\s*#", line):
-                continue
-            status, ID, xSex, xDGM, ySex, yDGM, sky = [float(el) for el in line.split()]
-            s = self.ssTruth.addNew()
-            s.setId(int(ID))
-            s.set(self.ssTruth.table.getCentroidKey().getX(), xDGM)
-            s.set(self.ssTruth.table.getCentroidKey().getY(), yDGM)
+        with open(filename) as fd:
+            for line in fd.readlines():
+                if re.match(r"\s*#", line):
+                    continue
+                status, ID, xSex, xDGM, ySex, yDGM, sky = [float(el) for el in line.split()]
+                s = self.ssTruth.addNew()
+                s.setId(int(ID))
+                s.set(self.ssTruth.table.getCentroidKey().getX(), xDGM)
+                s.set(self.ssTruth.table.getCentroidKey().getY(), yDGM)
 
     def testMeasureCentroid(self):
         """Test that we can instantiate and play with a measureCentroid"""


### PR DESCRIPTION
Ensures that the dummy classes registered in one test are still valid so that a later test will not complain about them.

Also make flake8 clean and fix a couple of warnings. The remaining flake8 warnings are caused by Doxygen `##` syntax. @jonathansick I am assuming that they will be fixed as part of the migration to numpydoc.