### PR TITLE
DM-13854: forcedPhotCoadd: add command-line PSF cache configuration

### DIFF
--- a/python/lsst/meas/base/forcedPhotCoadd.py
+++ b/python/lsst/meas/base/forcedPhotCoadd.py
@@ -71,6 +71,14 @@ class ForcedPhotCoaddConfig(ForcedPhotImageConfig):
 ## @}
 
 
+class ForcedPhotCoaddRunner(lsst.pipe.base.ButlerInitializedTaskRunner):
+    """Get the psfCache setting into ForcedPhotCoaddTask"""
+    @staticmethod
+    def getTargetList(parsedCmd, **kwargs):
+        return lsst.pipe.base.ButlerInitializedTaskRunner.getTargetList(parsedCmd,
+                                                                        psfCache=parsedCmd.psfCache)
+
+
 class ForcedPhotCoaddTask(ForcedPhotImageTask):
     """!
     A command-line driver for performing forced measurement on coadd images
@@ -169,4 +177,5 @@ class ForcedPhotCoaddTask(ForcedPhotImageTask):
         parser = lsst.pipe.base.ArgumentParser(name=cls._DefaultName)
         parser.add_id_argument("--id", "deepCoadd_forced_src", help="data ID, with raw CCD keys + tract",
                                ContainerClass=lsst.coadd.utils.CoaddDataIdContainer)
+        parser.add_argument("--psfCache", type=int, default=100, help="Size of CoaddPsf cache")
         return parser

--- a/python/lsst/meas/base/forcedPhotImage.py
+++ b/python/lsst/meas/base/forcedPhotImage.py
@@ -120,7 +120,7 @@ class ForcedPhotImageTask(lsst.pipe.base.CmdLineTask):
             self.makeSubtask("applyApCorr", schema=self.measurement.schema)
         self.makeSubtask('catalogCalculation', schema=self.measurement.schema)
 
-    def run(self, dataRef):
+    def run(self, dataRef, psfCache=None):
         """!Measure a single exposure using forced detection for a reference catalog.
 
         @param[in]  dataRef   An lsst.daf.persistence.ButlerDataRef. It is passed to the
@@ -135,9 +135,13 @@ class ForcedPhotImageTask(lsst.pipe.base.CmdLineTask):
                               passed to the writeOutputs() method (implemented by derived classes)
                               which writes the outputs.  See derived class documentation for which
                               datasets and data ID keys are used.
+        @param[in]  psfCache  Size of PSF cache, or None. The size of the PSF cache can have
+                              a significant effect upon the runtime for complicated PSF models.
         """
         refWcs = self.references.getWcs(dataRef)
         exposure = self.getExposure(dataRef)
+        if psfCache is not None:
+            exposure.getPsf().setCacheSize(psfCache)
         refCat = self.fetchReferences(dataRef, exposure)
         measCat = self.measurement.generateMeasCat(exposure, refCat, refWcs,
                                                    idFactory=self.makeIdFactory(dataRef))


### PR DESCRIPTION
The size of the PSF cache can have a significant effect upon the runtime
for complicated PSF models. For coadds, CoaddPsf can be complicated.