### PR TITLE
DM-14842: Fix deprecation warnings from PropertyList/Set.get

### DIFF
--- a/python/lsst/meas/base/measurementInvestigationLib.py
+++ b/python/lsst/meas/base/measurementInvestigationLib.py
@@ -53,15 +53,15 @@ def rebuildNoiseReplacer(exposure, measCat):
     algMetadata = measCat.getMetadata()
     noiseReplacerConf = NoiseReplacerConfig()
     noiseReplacerConf.noiseSeedMultiplier = \
-        algMetadata.get(SFMT.NOISE_SEED_MULTIPLIER)
-    noiseReplacerConf.noiseSource = algMetadata.get(SFMT.NOISE_SOURCE)
-    noiseReplacerConf.noiseOffset = algMetadata.get(SFMT.NOISE_OFFSET)
+        algMetadata.getScalar(SFMT.NOISE_SEED_MULTIPLIER)
+    noiseReplacerConf.noiseSource = algMetadata.getScalar(SFMT.NOISE_SOURCE)
+    noiseReplacerConf.noiseOffset = algMetadata.getScalar(SFMT.NOISE_OFFSET)
 
     footprints = {src.getId(): (src.getParent(), src.getFootprint())
                   for src in measCat}
 
     try:
-        exposureId = algMetadata.get(SFMT.NOISE_EXPOSURE_ID)
+        exposureId = algMetadata.getScalar(SFMT.NOISE_EXPOSURE_ID)
     except Exception:
         exposureId = None
 

--- a/tests/test_ApertureFlux.py
+++ b/tests/test_ApertureFlux.py
@@ -167,7 +167,7 @@ class CircularApertureFluxTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase)
         task = self.makeSingleFrameMeasurementTask(config=config, algMetadata=algMetadata)
         exposure, catalog = self.dataset.realize(10.0, task.schema, randomSeed=0)
         task.run(catalog, exposure)
-        radii = algMetadata.get("%s_radii" % (baseName,))
+        radii = algMetadata.getArray("%s_radii" % (baseName,))
         self.assertEqual(list(radii), list(ctrl.radii))
         for record in catalog:
             lastFlux = 0.0
@@ -215,7 +215,7 @@ class CircularApertureFluxTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase)
         baseName = "base_CircularApertureFlux"
         algMetadata = lsst.daf.base.PropertyList()
         task = self.makeForcedMeasurementTask(baseName, algMetadata=algMetadata)
-        radii = algMetadata.get("%s_radii" % (baseName,))
+        radii = algMetadata.getArray("%s_radii" % (baseName,))
         measWcs = self.dataset.makePerturbedWcs(self.dataset.exposure.getWcs(), randomSeed=1)
         measDataset = self.dataset.transform(measWcs)
         exposure, truthCatalog = measDataset.realize(10.0, measDataset.makeMinimalSchema(), randomSeed=1)


### PR DESCRIPTION
Use `getScalar` or `getArray` instead of deprecated `get`
on `PropertySet` and `PropertyList` instances.