### PR TITLE
DM-29767: Take absolute value of deviation to compare with uncertainty measures

### DIFF
--- a/tests/test_GaussianFlux.py
+++ b/tests/test_GaussianFlux.py
@@ -100,7 +100,7 @@ class GaussianFluxTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
             instFluxErrMean = np.mean(instFluxErrs)
             instFluxStandardDeviation = np.std(instFluxes)
             self.assertFloatsAlmostEqual(instFluxErrMean, instFluxStandardDeviation, rtol=0.10)
-            self.assertLess(instFluxMean - instFlux, 2.0*instFluxErrMean / nSamples**0.5)
+            self.assertLess(abs(instFluxMean - instFlux), 2.0*instFluxErrMean / nSamples**0.5)
 
     def testForcedPlugin(self):
         task = self.makeForcedMeasurementTask("base_GaussianFlux")

--- a/tests/test_PsfFlux.py
+++ b/tests/test_PsfFlux.py
@@ -148,7 +148,7 @@ class PsfFluxTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
             instFluxErrMean = np.mean(instFluxErrs)
             instFluxStandardDeviation = np.std(instFluxes)
             self.assertFloatsAlmostEqual(instFluxErrMean, instFluxStandardDeviation, rtol=0.10)
-            self.assertLess(instFluxMean - instFlux, 2.0*instFluxErrMean / nSamples**0.5)
+            self.assertLess(abs(instFluxMean - instFlux), 2.0*instFluxErrMean / nSamples**0.5)
 
     def testSingleFramePlugin(self):
         task = self.makeSingleFrameMeasurementTask("base_PsfFlux")

--- a/tests/test_SdssCentroid.py
+++ b/tests/test_SdssCentroid.py
@@ -116,8 +116,8 @@ class SdssCentroidTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
             yStandardDeviation = np.std(yList)
             self.assertFloatsAlmostEqual(xErrMean, xStandardDeviation, rtol=0.2)   # rng dependent
             self.assertFloatsAlmostEqual(yErrMean, yStandardDeviation, rtol=0.2)   # rng dependent
-            self.assertLess(xMean - x, 3.0*xErrMean / nSamples**0.5)   # rng dependent
-            self.assertLess(yMean - y, 3.0*yErrMean / nSamples**0.5)   # rng dependent
+            self.assertLess(abs(xMean - x), 3.0*xErrMean / nSamples**0.5)   # rng dependent
+            self.assertLess(abs(yMean - y), 3.0*yErrMean / nSamples**0.5)   # rng dependent
 
     def testEdge(self):
         task = self.makeSingleFrameMeasurementTask("base_SdssCentroid")


### PR DESCRIPTION
In a few unit tests, the signed deviation is checked against a positive number and the assertion is True if the deviation is lesser than the estimated uncertainty. The assertion would pass for large negative deviations, which the unit test is supposed to catch. The fixes in this PR take absolute value of the deviations before comparing to the estimated uncertainties.