### PR TITLE
DM-30015: Update Sphinx conf.py for documenteer 0.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,8 @@
+#########
+meas_base
+#########
+
+``meas_base`` is a package in the `LSST Science Pipelines <https://pipelines.lsst.io>`_.
+
+The ``lsst.meas.base`` Python module provides core astronomical measurement algorithms and base classes.
+Documentation is available at https://pipelines.lsst.io/modules/lsst.meas.base/index.html .

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,13 +1,13 @@
 """Sphinx configuration file for an LSST stack package.
-
-This configuration only affects single-package Sphinx documenation builds.
+This configuration only affects single-package Sphinx documentation builds.
+For more information, see:
+https://developer.lsst.io/stack/building-single-package-docs.html
 """
 
-from documenteer.sphinxconfig.stackconf import build_package_configs
-import lsst.meas.base
+from documenteer.conf.pipelinespkg import *
 
 
-_g = globals()
-_g.update(build_package_configs(
-    project_name='meas_base',
-    version=lsst.meas.base.version.__version__))
+project = "meas_base"
+html_theme_options["logotext"] = project
+html_title = project
+html_short_title = project

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,13 @@
 max-line-length = 110
 # TODO: remove E266 when Task documentation is converted to rst in DM-14207.
 ignore = E133, E226, E228, N802, N803, N806, E266, N812, N815, N816, W503
-exclude = __init__.py, tests/testLib.py
+exclude = 
+    bin,
+    doc/conf.py,
+    **/*/__init__.py,
+    **/*/version.py,
+    tests/.tests,
+    tests/testLib.py
 
 [tool:pytest]
 addopts = --flake8


### PR DESCRIPTION
Updates based on the latest updates in the package template (https://github.com/lsst/templates/tree/master/project_templates/stack_package)

- Add a basic README
- Update doc/conf.py for the documenteer 0.6 Sphinx configuration API