### PR TITLE
DM-31528: Add more log messages to the measure task

### DIFF
--- a/python/lsst/meas/base/forcedMeasurement.py
+++ b/python/lsst/meas/base/forcedMeasurement.py
@@ -56,6 +56,7 @@ Command-line driver tasks for forced measurement include
 
 import lsst.pex.config
 import lsst.pipe.base
+import time
 
 from .pluginRegistry import PluginRegistry
 from .baseMeasurement import (BaseMeasurementPluginConfig, BaseMeasurementPlugin,
@@ -190,17 +191,20 @@ class ForcedMeasurementConfig(BaseMeasurementConfig):
         default=[],
         doc="Plugins to run on undeblended image"
     )
-
     copyColumns = lsst.pex.config.DictField(
         keytype=str, itemtype=str, doc="Mapping of reference columns to source columns",
         default={"id": "objectId", "parent": "parentObjectId", "deblend_nChild": "deblend_nChild",
                  "coord_ra": "coord_ra", "coord_dec": "coord_dec"}
     )
-
     checkUnitsParseStrict = lsst.pex.config.Field(
         doc="Strictness of Astropy unit compatibility check, can be 'raise', 'warn' or 'silent'",
         dtype=str,
         default="raise",
+    )
+    loggingInterval = lsst.pex.config.Field(
+        dtype=int,
+        default=600,
+        doc="Interval (in seconds) to log messages (at VERBOSE level) while running measurement plugins."
     )
 
     def setDefaults(self):
@@ -336,6 +340,7 @@ class ForcedMeasurementTask(BaseMeasurementTask):
 
         self.log.info("Performing forced measurement on %d source%s", len(refCat),
                       "" if len(refCat) == 1 else "s")
+        nextLogTime = time.time() + self.config.loggingInterval
 
         if self.config.doReplaceWithNoise:
             noiseReplacer = NoiseReplacer(self.config.noiseReplacer, exposure,
@@ -376,6 +381,11 @@ class ForcedMeasurementTask(BaseMeasurementTask):
             self.callMeasureN(measChildCat, exposure, refChildCat,
                               beginOrder=beginOrder, endOrder=endOrder)
             noiseReplacer.removeSource(refParentRecord.getId())
+            # Log a message if it has been a while since the last log.
+            if (currentTime := time.time()) > nextLogTime:
+                self.log.verbose("Forced measurement complete for %d parents (and their children) out of %d",
+                                 parentIdx + 1, len(refParentCat))
+                nextLogTime = currentTime + self.config.loggingInterval
         noiseReplacer.end()
 
         # Undeblended plugins only fire if we're running everything

--- a/python/lsst/meas/base/forcedMeasurement.py
+++ b/python/lsst/meas/base/forcedMeasurement.py
@@ -390,9 +390,13 @@ class ForcedMeasurementTask(BaseMeasurementTask):
 
         # Undeblended plugins only fire if we're running everything
         if endOrder is None:
-            for measRecord, refRecord in zip(measCat, refCat):
+            for recordIndex, (measRecord, refRecord) in enumerate(zip(measCat, refCat)):
                 for plugin in self.undeblendedPlugins.iter():
                     self.doMeasurement(plugin, measRecord, exposure, refRecord, refWcs)
+                if (currentTime := time.time()) > nextLogTime:
+                    self.log.verbose("Undeblended forced measurement complete for %d sources out of %d",
+                                     recordIndex + 1, len(refCat))
+                    nextLogTime = currentTime + self.config.loggingInterval
 
     def generateMeasCat(self, exposure, refCat, refWcs, idFactory=None):
         r"""Initialize an output catalog from the reference catalog.

--- a/python/lsst/meas/base/sfm.py
+++ b/python/lsst/meas/base/sfm.py
@@ -338,9 +338,14 @@ class SingleFrameMeasurementTask(BaseMeasurementTask):
 
         # Undeblended plugins only fire if we're running everything
         if endOrder is None:
-            for source in measCat:
+            for sourceIndex, source in enumerate(measCat):
                 for plugin in self.undeblendedPlugins.iter():
                     self.doMeasurement(plugin, source, exposure)
+                if (currentTime := time.time()) > nextLogTime:
+                    self.log.verbose("Undeblended measurement complete for %d sources out of %d",
+                                     sourceIndex + 1, nMeasCat)
+                    nextLogTime = currentTime + self.config.loggingInterval
+
         # Now we loop over all of the sources one more time to compute the
         # blendedness metrics
         if self.doBlendedness:


### PR DESCRIPTION
The changes in the PR ensures that logging happens (at VERBOSE level) at least every 10 minutes (or at an interval that is configurable) when measurement is run.