### PR TITLE
Update headers for NaiveCentroid and SdssCentroid

### DIFF
--- a/include/lsst/meas/base/CentroidUtilities.h
+++ b/include/lsst/meas/base/CentroidUtilities.h
@@ -208,7 +208,8 @@ public:
      *  @param[in,out] schema        Schema to which the flag_resetToPeak is to be added
      *  @param[in]  name             The name of the algorithm we will be checking
      *  @param[in]  doFootprintCheck Check if centroid is within footprint
-     *  @param[in]  maxDistFromPeak Check if centroid is more than dist from footprint peak
+     *  @param[in]  maxDistFromPeak  If >0; maximum distance in pixels between the footprint
+     *                                peak and centroid allowed before resetToPeak flag is set.
      */
     CentroidChecker(afw::table::Schema& schema, std::string const& name, bool inside = true,
                     double maxDistFromPeak = -1.0);

--- a/include/lsst/meas/base/NaiveCentroid.h
+++ b/include/lsst/meas/base/NaiveCentroid.h
@@ -46,7 +46,8 @@ public:
     LSST_CONTROL_FIELD(background, double, "Value to subtract from the image pixel values");
     LSST_CONTROL_FIELD(doFootprintCheck, bool, "Do check that the centroid is contained in footprint.");
     LSST_CONTROL_FIELD(maxDistToPeak, double,
-                       "If set > 0, Centroid Check also checks distance from footprint peak.");
+                       "If >0; maximum distance in pixels between the footprint peak and centroid allowed before "
+                       "resetToPeak flag is set.");
 
     /**
      *  @brief Default constructor

--- a/include/lsst/meas/base/SdssCentroid.h
+++ b/include/lsst/meas/base/SdssCentroid.h
@@ -52,7 +52,8 @@ public:
     LSST_CONTROL_FIELD(wfac, double, "fiddle factor for adjusting the binning");
     LSST_CONTROL_FIELD(doFootprintCheck, bool, "Do check that the centroid is contained in footprint.");
     LSST_CONTROL_FIELD(maxDistToPeak, double,
-                       "If set > 0, Centroid Check also checks distance from footprint peak.");
+                       "If >0; maximum distance in pixels between the footprint peak and centroid allowed before "
+                       "resetToPeak flag is set.");
     /**
      *  @brief Default constructor
      *


### PR DESCRIPTION
maxDistToPeak documentation has been clarified that it is units of pixels. Updated the docstring to also clarify that it is measure the maximum distance allowed before the resetToPeak flag is set.