### PR TITLE
DM-43599: Add progress logs to DiaObjectCalculationTask

### DIFF
--- a/python/lsst/meas/base/diaCalculation.py
+++ b/python/lsst/meas/base/diaCalculation.py
@@ -449,10 +449,12 @@ class DiaObjectCalculationTask(CatalogCalculationTask):
         else:
             filterDiaSourcesGB = None
 
+        log_band = "band " + band if band else "no band"
         for runlevel in sorted(self.executionDict):
             for plug in self.executionDict[runlevel].single:
                 if plug.needsFilter ^ bool(band):
                     continue
+                self.log.verbose("Running plugin %s on %s.", plug.name, log_band)
 
                 for updatedDiaObjectId in updatedDiaObjectIds:
                     # Sub-select diaSources associated with this diaObject.
@@ -482,6 +484,7 @@ class DiaObjectCalculationTask(CatalogCalculationTask):
             for plug in self.executionDict[runlevel].multi:
                 if plug.needsFilter ^ bool(band):
                     continue
+                self.log.verbose("Running plugin %s on %s.", plug.name, log_band)
                 with CCContext(plug, diaObjectsToUpdate, self.log):
                     plug.calculate(diaObjects=diaObjectsToUpdate,
                                    diaSources=diaSourcesGB,

--- a/python/lsst/meas/base/diaCalculation.py
+++ b/python/lsst/meas/base/diaCalculation.py
@@ -284,8 +284,8 @@ class DiaObjectCalculationTask(CatalogCalculationTask):
 
         Run method both updates the values in the diaObjectCat and appends
         newly created DiaObjects to the catalog. For catalog column names
-        see the lsst.cat schema definitions for the DiaObject and DiaSource
-        tables (http://github.com/lsst/cat).
+        see the SDM schema definitions for the DiaObject and DiaSource
+        tables (http://github.com/lsst/sdm_schemas/).
 
         Parameters
         ----------
@@ -350,8 +350,8 @@ class DiaObjectCalculationTask(CatalogCalculationTask):
                     filterNames):
         """Run each of the plugins on the catalog.
 
-        For catalog column names see the lsst.cat schema definitions for the
-        DiaObject and DiaSource tables (http://github.com/lsst/cat).
+        For catalog column names see the SDM schema definitions for the
+        DiaObject and DiaSource tables (http://github.com/lsst/sdm_schemas/).
 
         Parameters
         ----------

--- a/python/lsst/meas/base/diaCalculation.py
+++ b/python/lsst/meas/base/diaCalculation.py
@@ -448,6 +448,7 @@ class DiaObjectCalculationTask(CatalogCalculationTask):
                                 "DiaObjectId={updatedDiaObjectId} has no "
                                 "DiaSources for filter=%s. "
                                 "Continuing...", band)
+                            continue
                         with CCContext(plug, updatedDiaObjectId, self.log):
                             # We feed the catalog we need to update and the id
                             # so as to get a few into the catalog and not a copy.

--- a/python/lsst/meas/base/diaCalculation.py
+++ b/python/lsst/meas/base/diaCalculation.py
@@ -291,11 +291,11 @@ class DiaObjectCalculationTask(CatalogCalculationTask):
         ----------
         diaObjectCat : `pandas.DataFrame`
             DiaObjects to update values of and append new objects to. DataFrame
-            should be indexed on "diaObjectId"
+            should be indexed on "diaObjectId".
         diaSourceCat : `pandas.DataFrame`
             DiaSources associated with the DiaObjects in diaObjectCat.
             DataFrame should be indexed on
-            `["diaObjectId", "band", "diaSourceId"]`
+            ["diaObjectId", "band", "diaSourceId"].
         updatedDiaObjectIds : `numpy.ndarray`
             Integer ids of the DiaObjects to update and create.
         filterNames : `list` of `str`
@@ -357,11 +357,11 @@ class DiaObjectCalculationTask(CatalogCalculationTask):
         ----------
         diaObjectCat : `pandas.DataFrame`
             DiaObjects to update values of and append new objects to. DataFrame
-            should be indexed on "diaObjectId"
+            should be indexed on "diaObjectId".
         diaSourceCat : `pandas.DataFrame`
             DiaSources associated with the DiaObjects in diaObjectCat.
             DataFrame must be indexed on
-            ["diaObjectId", "band", "diaSourceId"]`
+            ["diaObjectId", "band", "diaSourceId"].
         updatedDiaObjectIds : `numpy.ndarray`
             Integer ids of the DiaObjects to update and create.
         filterNames : `list` of `str`


### PR DESCRIPTION
This PR merges some duplicate code in `DiaObjectCalculationTask`, and adds some logging to the outer execution loops of this sometimes long-running task.

Unfortunately, `git diff` badly garbled 8e97c3c because of the duplication; it may be easier to compare the [before](https://github.com/lsst/meas_base/blob/4d0e229738f3ec19994a3f2cdcf2d768a6da449d/python/lsst/meas/base/diaCalculation.py#L393) and [after](https://github.com/lsst/meas_base/blob/8e97c3c88b0f1c6114b05fade7f09bbaca922ac4/python/lsst/meas/base/diaCalculation.py#L393) repository states.