### PR TITLE
DM-45342: meas.base.CCContext suppresses all raisables, not just exceptions

### DIFF
--- a/python/lsst/meas/base/catalogCalculation.py
+++ b/python/lsst/meas/base/catalogCalculation.py
@@ -145,7 +145,7 @@ class CCContext:
         if exc_type is None:
             return True
         if exc_type in FATAL_EXCEPTIONS:
-            raise exc_value
+            return False
         elif exc_type is MeasurementError:
             self.plugin.fail(self.cat, exc_value)
         elif issubclass(exc_type, Exception):

--- a/python/lsst/meas/base/catalogCalculation.py
+++ b/python/lsst/meas/base/catalogCalculation.py
@@ -148,8 +148,11 @@ class CCContext:
             raise exc_value
         elif exc_type is MeasurementError:
             self.plugin.fail(self.cat, exc_value)
-        else:
+        elif issubclass(exc_type, Exception):
             self.log.warning("Error in %s.calculate: %s", self.plugin.name, exc_value)
+        else:
+            # In general, BaseExceptions are unrelated to the code and should not be caught
+            return False
         return True
 
 


### PR DESCRIPTION
This PR fixes a bug in `CCContext` that caused it to intercept interrupts and treat them like algorithmic errors.