### PR TITLE
DM-45545: Trap NaN before calling boost API

### DIFF
--- a/src/SincCoeffs.cc
+++ b/src/SincCoeffs.cc
@@ -39,7 +39,15 @@ namespace base {
 namespace {
 
 // Convenient wrapper for a Bessel function
-inline double J1(double const x) { return boost::math::cyl_bessel_j(1, x); }
+inline double J1(double const x) {
+    // Some versions of boost assert that x >= 0
+    // which fails for NaN. Retain previous behavior
+    // and return NaN for NaN.
+    if (std::isnan(x)) {
+        return x;
+    }
+    return boost::math::cyl_bessel_j(1, x);
+}
 
 // sinc function
 template <typename T>


### PR DESCRIPTION
From v1.86 boost asserts that the bessel API is called with a positive value. Previously NaN was accepted. Now trap for NaN and return it before calling boost.