### PR TITLE
DM-49554: Do not attempt forced photometry in NO_DATA regions

### DIFF
--- a/python/lsst/meas/base/forcedMeasurement.py
+++ b/python/lsst/meas/base/forcedMeasurement.py
@@ -201,6 +201,11 @@ class ForcedMeasurementConfig(BaseMeasurementConfig):
         dtype=str,
         default="raise",
     )
+    badPixelFlags = lsst.pex.config.ListField(
+        dtype=str,
+        default=['base_PixelFlags_flag_nodataCenter',],
+        doc="If a source has a pixel flag in this list, it will NOT be measured.",
+    )
 
     def setDefaults(self):
         self.slots.centroid = "base_TransformedCentroid"
@@ -244,6 +249,7 @@ class ForcedMeasurementTask(BaseMeasurementTask):
     """
 
     ConfigClass = ForcedMeasurementConfig
+    _DefaultName = "forcedMeasurement"
 
     def __init__(self, refSchema, algMetadata=None, **kwds):
         super(ForcedMeasurementTask, self).__init__(algMetadata=algMetadata, **kwds)
@@ -257,6 +263,17 @@ class ForcedMeasurementTask(BaseMeasurementTask):
         self.initializePlugins(schemaMapper=self.mapper)
         self.schema = self.mapper.getOutputSchema()
         self.schema.checkUnits(parse_strict=self.config.checkUnitsParseStrict)
+
+        # Enforce a specific plugin order so that we can skip measurement on
+        # sources that have bad pixel flags. Centroid has to go first.
+        self.plugins_pre = self.plugins.copy()
+        self.plugins_post = self.plugins.copy()
+        self.plugins_pre.clear()
+        self.plugins_pre[self.config.slots.centroid] = self.plugins[self.config.slots.centroid]
+        self.plugins_pre["base_PixelFlags"] = self.plugins["base_PixelFlags"]
+        self.plugins_post.pop(self.config.slots.centroid)
+        self.plugins_post.pop("base_PixelFlags")
+        del self.plugins
 
     def run(self, measCat, exposure, refCat, refWcs, exposureId=None, beginOrder=None, endOrder=None):
         r"""Perform forced measurement.
@@ -352,10 +369,16 @@ class ForcedMeasurementTask(BaseMeasurementTask):
         else:
             noiseReplacer = DummyNoiseReplacer()
 
+        # Split running measurements into two parts: pre-measure and measure.
+        # The former runs only the Centroid and PixelFlagas plugins so we can
+        # skip measuring sources that have obviously bad pixel flags.
+        self._pre_measure(refCat, measCat, exposure, refWcs, beginOrder, endOrder)
+
         # Create parent cat which slices both the refCat and measCat (sources)
         # first, get the reference and source records which have no parent
         refParentCat, measParentCat = refCat.getChildren(0, measCat)
         childrenIter = refCat.getChildren((refParentRecord.getId() for refParentRecord in refCat), measCat)
+
         for parentIdx, records in enumerate(zip(refParentCat, measParentCat, childrenIter)):
             # Unpack records
             refParentRecord, measParentRecord, (refChildCat, measChildCat) = records
@@ -390,6 +413,31 @@ class ForcedMeasurementTask(BaseMeasurementTask):
                     self.doMeasurement(plugin, measRecord, exposure, refRecord, refWcs)
                     periodicLog.log("Undeblended forced measurement complete for %d sources out of %d",
                                     recordIndex + 1, len(refCat))
+
+    def _pre_measure(self, refCat, measCat, exposure, refWcs, beginOrder, endOrder):
+        """Run plugins in a specific order so we can skip measuring
+        sources that have obviously bad pixel flags.
+
+        The Parameters are identical to those in the run method.
+        """
+        # First, run just the Centroid plugin (it has to go first) and
+        # the base_PixelFlags plugin on the full catalog.
+        # We don't care about differentiating children from parents yet.
+        self.plugins = self.plugins_pre
+        for refRecord, measRecord in zip(refCat, measCat):
+            self.callMeasure(measRecord, exposure, refRecord, refWcs,
+                             beginOrder=beginOrder, endOrder=endOrder)
+
+        # Second, filter out the sources we don't want to measure,
+        # and ensure the measCat is contiguous
+        for badPixelFlag in self.config.badPixelFlags:
+            measCat = measCat[~measCat[badPixelFlag]]
+        if not measCat.isContiguous():
+            measCat = measCat.copy(deep=True)
+
+        # Finally, reset self.plugins so the Task can continue running all the
+        # rest of the measurement plugins.
+        self.plugins = self.plugins_post
 
     def generateMeasCat(self, exposure, refCat, refWcs, idFactory=None):
         r"""Initialize an output catalog from the reference catalog.

--- a/python/lsst/meas/base/tests.py
+++ b/python/lsst/meas/base/tests.py
@@ -707,7 +707,8 @@ class AlgorithmTestCase:
         arguments, the `TransformedCentroid` and `TransformedShape` plugins
         will be run and used as the centroid and shape slots; these simply
         transform the reference catalog centroid and shape to the measurement
-        coordinate system.
+        coordinate system. Also run the pixelFlags plugin, since it is
+        expected to run prior to all the other non-centroid plugins.
 
         Parameters
         ----------
@@ -731,6 +732,7 @@ class AlgorithmTestCase:
         config.slots.gaussianFlux = None
         config.plugins.names = (plugin,) + tuple(dependencies) + ("base_TransformedCentroid",
                                                                   "base_TransformedShape")
+        config.plugins.names |= ["base_PixelFlags"]
         return config
 
     def makeForcedMeasurementTask(self, plugin=None, dependencies=(), config=None, refSchema=None,

--- a/tests/test_PluginLogs.py
+++ b/tests/test_PluginLogs.py
@@ -160,15 +160,17 @@ class RegisteredPluginsTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
         task.log.setLevel(task.log.ERROR)
         task.run(measCat, exposure, refCat, refWcs)
         for pluginName in dependencies:
-            plugin = task.plugins[pluginName]
-            if hasattr(plugin, "hasLogName") and plugin.hasLogName:
-                child_log = task.log.getChild(pluginName)
-                self.assertEqual(plugin.getLogName(), child_log.name)
-                # if the plugin is cpp, check the cpp Algorithm as well
-                if hasattr(plugin, "cpp"):
-                    self.assertEqual(plugin.cpp.getLogName(), child_log.name)
-            else:
-                self.assertIsNone(plugin.getLogName())
+            # Exclude PixelFlags and Centroid plugins because they run before all the others
+            if (pluginName != "base_PixelFlags") and (pluginName != "base_TransformedCentroid"):
+                plugin = task.plugins[pluginName]
+                if hasattr(plugin, "hasLogName") and plugin.hasLogName:
+                    child_log = task.log.getChild(pluginName)
+                    self.assertEqual(plugin.getLogName(), child_log.name)
+                    # if the plugin is cpp, check the cpp Algorithm as well
+                    if hasattr(plugin, "cpp"):
+                        self.assertEqual(plugin.cpp.getLogName(), child_log.name)
+                else:
+                    self.assertIsNone(plugin.getLogName())
 
 
 class LoggingPythonTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):


### PR DESCRIPTION
This PR changes forcedMeasurementTask so it skips measuring sources with `pixelFlags_nodataCenter`.

This approach is inspired by ip_diffim's dipoleFitTask. We have to run the centroid plugin first, and then we run PixelFlags next so we can drop sources from the measCat before other plugins are run. By default, only sources with the nodataCenter flag are dropped. In practice, most NO_DATA regions are from template holes in diffims, so the result will be an identical length mergedForcedSource table but with NaNs for the fluxes of the obviously garbage diaSources.